### PR TITLE
Fix hooks returning wrong type - add return 0 to all hook methods

### DIFF
--- a/class/actions_verifactu.class.php
+++ b/class/actions_verifactu.class.php
@@ -165,6 +165,7 @@ class ActionsVerifactu
 				}
 			}
 		}
+		return 0;
 	}
 
 	public function dolGetButtonAction($parameters, &$object, &$action, $hookmanager)
@@ -221,6 +222,7 @@ class ActionsVerifactu
 				}
 			}
 		}
+		return 0;
 	}
 
 
@@ -260,6 +262,7 @@ class ActionsVerifactu
 	public function addMoreActionsButtons($parameters, &$object, &$action, $hookmanager)
 	{
 		// Empty function - help functionality removed
+		return 0;
 	}
 
 
@@ -633,7 +636,9 @@ class ActionsVerifactu
 				}
 			}
 		} catch (\Throwable $th) {
+			dol_syslog(get_class($this) . '::moreHtmlStatus error: ' . $th->getMessage(), LOG_ERR);
 		}
+		return 0;
 	}
 
 	public function formDolBanner(&$parameters, &$object, &$action, $hookmanager)
@@ -663,6 +668,7 @@ class ActionsVerifactu
 			// Handle exception
 			dol_syslog(get_class($this) . '::formDolBanner error: ' . $th->getMessage(), LOG_ERR);
 		}
+		return 0;
 	}
 
 	public function printCommonFooter(&$parameters, &$object, &$action, $hookmanager)
@@ -673,6 +679,7 @@ class ActionsVerifactu
 			// Disable select with id forcedate
 			echo '<script>document.getElementById("forcedate").disabled = true;</script>';
 		}
+		return 0;
 	}
 
 	public function TakeposReceipt(&$parameters, &$object, &$action, $hookmanager)
@@ -1089,6 +1096,7 @@ class ActionsVerifactu
 		if ($object->fetch_optionals() && $object->array_options['options_verifactu_factura_tipo'] == Sietekas\Verifactu\VerifactuInvoice::TYPE_SIMPLIFIED) {
 			$langs->tab_translate["PdfInvoiceTitle"] = $langs->trans("verifactu_FACTURA_Simplificada"); // Translation ID for "Simplified Invoice"
 		}
+		return 0;
 	}
 
 }

--- a/class/verifactu.utils.php
+++ b/class/verifactu.utils.php
@@ -3,7 +3,6 @@
 // Required Dolibarr includes
 dol_include_once('/compta/facture/class/facture.class.php');
 dol_include_once('/verifactu/lib/verifactu.lib.php');
-dol_include_once('/verifactu/lib/functions/funciones.utilidades.php');
 
 /**
  *		Class to manage utility methods

--- a/core/triggers/interface_999_modVerifactu_VerifactuTriggers.class.php
+++ b/core/triggers/interface_999_modVerifactu_VerifactuTriggers.class.php
@@ -30,7 +30,6 @@
 
 require_once DOL_DOCUMENT_ROOT . '/core/triggers/dolibarrtriggers.class.php';
 dol_include_once('/verifactu/lib/verifactu.lib.php');
-dol_include_once('/verifactu/lib/functions/funciones.utilidades.php');
 
 /**
  *  Class of triggers for Verifactu module


### PR DESCRIPTION
All Dolibarr hooks must return an int (0=OK, 1=Replace, -1=KO) but several methods were not returning anything, causing errors like: "Bug into hook X. Method must not return a string but an int"

Fixed methods in actions_verifactu.class.php:
- doActions: added return 0
- dolGetButtonAction: added return 0
- addMoreActionsButtons: added return 0
- moreHtmlStatus: added return 0 and error logging
- formDolBanner: added return 0
- printCommonFooter: added return 0
- beforePDFCreation: added return 0

Also fixed invalid include references:
- Removed obsolete include to non-existent funciones.utilidades.php (functions are already loaded via verifactu.lib.php)