### PR TITLE
Add setup menu and certificate key translations

### DIFF
--- a/langs/ca_ES/verifactu.lang
+++ b/langs/ca_ES/verifactu.lang
@@ -49,6 +49,8 @@ VERIFACTU_CERTIFICATE_TOOLTIP = Certificat de signatura electrònica per a VeriF
 VERIFACTU_CERTIFICATE_PASSWORD = Contrasenya del certificat
 VERIFACTU_CERTIFICATE_PRIVATE_KEY = Clau privada
 VERIFACTU_CERTIFICATE_PRIVATE_KEY_HELP = Si el servidor només proporciona certificat públic, enganxeu aquí la clau privada. El sistema afegeix les etiquetes PEM automàticament si falten.
+VERIFACTU_CERTIFICATE_KEY = Clau del certificat
+VERIFACTU_CERTIFICATE_KEY_HELP = Contrasenya o clau del certificat digital per a la signatura electrònica.
 VERIFACTU_LOCAL_USE_CERTIFICATE = Usar certificat local
 VERIFACTU_LOCAL_USE_CERTIFICATE_HELP = Si està actiu, usa un certificat local (.pfx, .p12 o .pem). Si no, combineu la clau privada amb el certificat del servidor de llicències.
 sendInvoicesWithErrorsCronName = VeriFactu - Reenviament de factures amb errors de connexió
@@ -554,3 +556,11 @@ VERIFACTU_VERIFY_NOT_FOUND_CLEARED = Factura %s no existeix a AEAT. Errors anter
 VERIFACTU_VERIFY_STATUS_CORRECTED = Factura %s verificada. Estat: Enviada. Import: %s
 VERIFACTU_VERIFY_AMOUNTS_DIFFER = Factura %s a AEAT amb imports diferents: Dolibarr=%s, AEAT=%s (diferència: %s). Requereix revisió.
 VERIFACTU_VERIFY_SUCCESS_SUMMARY = Verificació exitosa: Imports coincideixen (Dolibarr: %s, AEAT: %s)
+
+# Help / FAQ Menu
+VERIFACTU_HELP_MENU = Ajuda
+VERIFACTU_HELP_MENU_HELP = Guia d'ajuda i preguntes freqüents sobre VeriFactu
+
+# Setup Menu
+VERIFACTU_SETUP = Configuració
+VERIFACTU_SETUP_MENU_HELP = Configuració del mòdul VeriFactu

--- a/langs/en_US/verifactu.lang
+++ b/langs/en_US/verifactu.lang
@@ -49,6 +49,8 @@ VERIFACTU_CERTIFICATE_TOOLTIP = Digital signature certificate for VeriFactu. PEM
 VERIFACTU_CERTIFICATE_PASSWORD = Certificate Password
 VERIFACTU_CERTIFICATE_PRIVATE_KEY = Private Key
 VERIFACTU_CERTIFICATE_PRIVATE_KEY_HELP = If the server only provides a public certificate, paste your private key here. The system adds PEM tags automatically if missing.
+VERIFACTU_CERTIFICATE_KEY = Certificate Key
+VERIFACTU_CERTIFICATE_KEY_HELP = Password or key for the digital certificate used for electronic signature.
 VERIFACTU_LOCAL_USE_CERTIFICATE = Use Local Certificate
 VERIFACTU_LOCAL_USE_CERTIFICATE_HELP = If enabled, uses a local certificate (.pfx, .p12 or .pem). Otherwise, combine the private key with the license server certificate.
 sendInvoicesWithErrorsCronName = VeriFactu - Resend invoices with connection errors
@@ -558,6 +560,10 @@ VERIFACTU_VERIFY_SUCCESS_SUMMARY = Verification successful: Amounts match (Dolib
 # Help / FAQ Menu
 VERIFACTU_HELP_MENU = Help
 VERIFACTU_HELP_MENU_HELP = Help guide and frequently asked questions about VeriFactu
+
+# Setup Menu
+VERIFACTU_SETUP = Setup
+VERIFACTU_SETUP_MENU_HELP = VeriFactu module configuration
 
 # FAQ Page
 VERIFACTU_FAQ_TITLE = VeriFactu Help Guide

--- a/langs/es_ES/verifactu.lang
+++ b/langs/es_ES/verifactu.lang
@@ -49,6 +49,8 @@ VERIFACTU_CERTIFICATE_TOOLTIP = Certificado de firma electrónica para VeriFactu
 VERIFACTU_CERTIFICATE_PASSWORD = Contraseña del certificado
 VERIFACTU_CERTIFICATE_PRIVATE_KEY = Clave privada
 VERIFACTU_CERTIFICATE_PRIVATE_KEY_HELP = Si el servidor solo proporciona certificado público, pegue aquí la clave privada. El sistema añade las etiquetas PEM automáticamente si faltan.
+VERIFACTU_CERTIFICATE_KEY = Clave del certificado
+VERIFACTU_CERTIFICATE_KEY_HELP = Contraseña o clave del certificado digital para la firma electrónica.
 VERIFACTU_LOCAL_USE_CERTIFICATE = Usar certificado local
 VERIFACTU_LOCAL_USE_CERTIFICATE_HELP = Si está activo, usa un certificado local (.pfx, .p12 o .pem). Si no, combine la clave privada con el certificado del servidor de licencias.
 sendInvoicesWithErrorsCronName = VeriFactu - Reenvío de facturas con errores de conexión
@@ -558,6 +560,10 @@ VERIFACTU_VERIFY_SUCCESS_SUMMARY = Verificación exitosa: Importes coinciden (Do
 # Help / FAQ Menu
 VERIFACTU_HELP_MENU = Ayuda
 VERIFACTU_HELP_MENU_HELP = Guía de ayuda y preguntas frecuentes sobre VeriFactu
+
+# Setup Menu
+VERIFACTU_SETUP = Configuración
+VERIFACTU_SETUP_MENU_HELP = Configuración del módulo VeriFactu
 
 # FAQ Page
 VERIFACTU_FAQ_TITLE = Guía de Ayuda VeriFactu

--- a/langs/eu_ES/verifactu.lang
+++ b/langs/eu_ES/verifactu.lang
@@ -49,6 +49,8 @@ VERIFACTU_CERTIFICATE_TOOLTIP = VeriFactu-rako sinadura elektronikoko ziurtagiri
 VERIFACTU_CERTIFICATE_PASSWORD = Ziurtagiriaren pasahitza
 VERIFACTU_CERTIFICATE_PRIVATE_KEY = Gako pribatua
 VERIFACTU_CERTIFICATE_PRIVATE_KEY_HELP = Zerbitzariak ziurtagiri publikoa bakarrik ematen badu, itsatsi hemen gako pribatua. Sistemak PEM etiketak automatikoki gehitzen ditu falta badira.
+VERIFACTU_CERTIFICATE_KEY = Ziurtagiriaren gakoa
+VERIFACTU_CERTIFICATE_KEY_HELP = Sinadura elektronikorako ziurtagiri digitalaren pasahitza edo gakoa.
 VERIFACTU_LOCAL_USE_CERTIFICATE = Ziurtagiri lokala erabili
 VERIFACTU_LOCAL_USE_CERTIFICATE_HELP = Aktibo badago, ziurtagiri lokala erabiltzen du (.pfx, .p12 edo .pem). Bestela, gako pribatua lizentzia zerbitzariaren ziurtagiriarekin konbinatzen du.
 sendInvoicesWithErrorsCronName = VeriFactu - Konexio erroreekin fakturen birbidaltzea
@@ -554,3 +556,11 @@ VERIFACTU_VERIFY_NOT_FOUND_CLEARED = %s faktura ez dago AEATen. Aurreko erroreak
 VERIFACTU_VERIFY_STATUS_CORRECTED = %s faktura egiaztatua. Egoera: Bidalia. Zenbatekoa: %s
 VERIFACTU_VERIFY_AMOUNTS_DIFFER = %s faktura AEATen zenbateko desberdinekin: Dolibarr=%s, AEAT=%s (aldea: %s). Berrikuspena behar du.
 VERIFACTU_VERIFY_SUCCESS_SUMMARY = Egiaztapen arrakastatsua: Zenbatekoak bat datoz (Dolibarr: %s, AEAT: %s)
+
+# Help / FAQ Menu
+VERIFACTU_HELP_MENU = Laguntza
+VERIFACTU_HELP_MENU_HELP = VeriFactu-ri buruzko laguntza gida eta maiz egiten diren galderak
+
+# Setup Menu
+VERIFACTU_SETUP = Konfigurazioa
+VERIFACTU_SETUP_MENU_HELP = VeriFactu moduluaren konfigurazioa

--- a/langs/gl_ES/verifactu.lang
+++ b/langs/gl_ES/verifactu.lang
@@ -49,6 +49,8 @@ VERIFACTU_CERTIFICATE_TOOLTIP = Certificado de sinatura electrónica para VeriFa
 VERIFACTU_CERTIFICATE_PASSWORD = Contrasinal do certificado
 VERIFACTU_CERTIFICATE_PRIVATE_KEY = Chave privada
 VERIFACTU_CERTIFICATE_PRIVATE_KEY_HELP = Se o servidor só proporciona certificado público, pegue aquí a chave privada. O sistema engade as etiquetas PEM automaticamente se faltan.
+VERIFACTU_CERTIFICATE_KEY = Chave do certificado
+VERIFACTU_CERTIFICATE_KEY_HELP = Contrasinal ou chave do certificado dixital para a sinatura electrónica.
 VERIFACTU_LOCAL_USE_CERTIFICATE = Usar certificado local
 VERIFACTU_LOCAL_USE_CERTIFICATE_HELP = Se está activo, usa un certificado local (.pfx, .p12 ou .pem). Se non, combine a chave privada co certificado do servidor de licenzas.
 sendInvoicesWithErrorsCronName = VeriFactu - Reenvío de facturas con erros de conexión
@@ -554,3 +556,11 @@ VERIFACTU_VERIFY_NOT_FOUND_CLEARED = Factura %s non existe na AEAT. Erros anteri
 VERIFACTU_VERIFY_STATUS_CORRECTED = Factura %s verificada. Estado: Enviada. Importe: %s
 VERIFACTU_VERIFY_AMOUNTS_DIFFER = Factura %s na AEAT con importes diferentes: Dolibarr=%s, AEAT=%s (diferenza: %s). Require revisión.
 VERIFACTU_VERIFY_SUCCESS_SUMMARY = Verificación exitosa: Importes coinciden (Dolibarr: %s, AEAT: %s)
+
+# Help / FAQ Menu
+VERIFACTU_HELP_MENU = Axuda
+VERIFACTU_HELP_MENU_HELP = Guía de axuda e preguntas frecuentes sobre VeriFactu
+
+# Setup Menu
+VERIFACTU_SETUP = Configuración
+VERIFACTU_SETUP_MENU_HELP = Configuración do módulo VeriFactu


### PR DESCRIPTION
Added to all 5 languages (es_ES, en_US, ca_ES, eu_ES, gl_ES):
- VERIFACTU_SETUP: Setup menu label
- VERIFACTU_SETUP_MENU_HELP: Setup menu tooltip
- VERIFACTU_CERTIFICATE_KEY: Certificate key label
- VERIFACTU_CERTIFICATE_KEY_HELP: Certificate key help text
- VERIFACTU_HELP_MENU (ca_ES, eu_ES, gl_ES): Help menu translations