### PR TITLE
Add responsible declaration configuration file per Spanish regulations

### DIFF
--- a/conf/declaracion_responsable.conf.php
+++ b/conf/declaracion_responsable.conf.php
@@ -1,0 +1,577 @@
+<?php
+/**
+ * Fichero de configuración para la Declaración Responsable VeriFactu
+ *
+ * Este fichero contiene todos los parámetros requeridos por la normativa española
+ * para la declaración responsable de sistemas informáticos de facturación.
+ *
+ * Marco Legal:
+ * - Real Decreto 1007/2023, de 5 de diciembre (Reglamento VeriFactu)
+ * - Real Decreto 254/2025 (Modificaciones y plazos)
+ * - Orden HAC/1177/2024, de 17 de octubre (Especificaciones técnicas)
+ * - Artículo 29.2.j) de la Ley 58/2003, General Tributaria
+ *
+ * @package    verifactu
+ * @subpackage conf
+ * @author     Germán Luis Aracil Boned <garacilb@gmail.com>
+ * @copyright  2025 Germán Luis Aracil Boned
+ * @license    GPL-3.0-or-later
+ * @version    1.0.0
+ * @since      2025-12-12
+ *
+ * @see https://www.boe.es/diario_boe/txt.php?id=BOE-A-2024-22138
+ * @see https://sede.agenciatributaria.gob.es/Sede/iva/sistemas-informaticos-facturacion-verifactu/
+ */
+
+if (!defined('VERIFACTU_DECLARACION_RESPONSABLE')) {
+    define('VERIFACTU_DECLARACION_RESPONSABLE', true);
+}
+
+/**
+ * =============================================================================
+ * SECCIÓN 1: DATOS DEL PRODUCTOR DEL SISTEMA INFORMÁTICO
+ * =============================================================================
+ * Según Artículo 15 de la Orden HAC/1177/2024
+ *
+ * El productor es la persona física o jurídica que desarrolla, fabrica o
+ * comercializa el sistema informático de facturación.
+ */
+$declaracionResponsable['productor'] = array(
+
+    /**
+     * Razón social o nombre completo del productor
+     * @required Obligatorio según Art. 15.1.a) Orden HAC/1177/2024
+     */
+    'razon_social' => 'Germán Luis Aracil Boned',
+
+    /**
+     * NIF español del productor
+     * Si no dispone de NIF español, utilizar 'nif_extranjero'
+     * @required Obligatorio según Art. 15.1.b) Orden HAC/1177/2024
+     */
+    'nif' => '',  // Completar con NIF válido
+
+    /**
+     * Identificación fiscal extranjera (si aplica)
+     * Solo si el productor no dispone de NIF español
+     */
+    'nif_extranjero' => array(
+        'tipo_identificacion' => '',  // Tipo de documento (passport, VAT, etc.)
+        'numero' => '',
+        'pais_emision' => '',  // Código ISO 3166-1 alpha-2
+    ),
+
+    /**
+     * Dirección postal completa del productor
+     * @required Obligatorio según Art. 15.1.c) Orden HAC/1177/2024
+     */
+    'direccion' => array(
+        'tipo_via' => 'Calle',
+        'nombre_via' => '',
+        'numero' => '',
+        'piso' => '',
+        'puerta' => '',
+        'codigo_postal' => '',
+        'localidad' => '',
+        'provincia' => '',
+        'pais' => 'España',
+        'codigo_pais' => 'ES',
+    ),
+
+    /**
+     * Datos de contacto del productor
+     * @recommended Recomendado para comunicaciones de la AEAT
+     */
+    'contacto' => array(
+        'email' => 'garacilb@gmail.com',
+        'telefono' => '',
+        'web' => 'https://github.com/garacil/verifactu',
+    ),
+);
+
+/**
+ * =============================================================================
+ * SECCIÓN 2: DATOS DEL SISTEMA INFORMÁTICO
+ * =============================================================================
+ * Según Artículo 15 de la Orden HAC/1177/2024
+ */
+$declaracionResponsable['sistema'] = array(
+
+    /**
+     * Nombre comercial del sistema informático
+     * Denominación genérica para su distribución/comercialización
+     * @required Obligatorio según Art. 15.2.a) Orden HAC/1177/2024
+     */
+    'nombre' => 'VeriFactu para Dolibarr ERP/CRM',
+
+    /**
+     * IdSistemaInformatico - Código identificador único
+     * Asignado por el productor para identificar unívocamente el sistema
+     * @required Obligatorio según Art. 15.2.b) Orden HAC/1177/2024
+     * @format Alfanumérico, máximo 30 caracteres
+     */
+    'id_sistema_informatico' => 'VERIFACTU-DOLIBARR-OSS',
+
+    /**
+     * Versión del sistema informático
+     * Identificador completo de la versión concreta
+     * @required Obligatorio según Art. 15.2.c) Orden HAC/1177/2024
+     */
+    'version' => '1.0.2',
+
+    /**
+     * Fecha de la versión
+     */
+    'fecha_version' => '2025-07-16',
+
+    /**
+     * Número de instalación/instancia (generado automáticamente)
+     * Identificador único de cada instalación
+     */
+    'numero_instalacion' => '',  // Se genera automáticamente con hash
+
+    /**
+     * Tipo de licencia del software
+     */
+    'tipo_licencia' => 'GPL-3.0-or-later',
+
+    /**
+     * URL del repositorio del código fuente
+     */
+    'repositorio' => 'https://github.com/garacil/verifactu',
+);
+
+/**
+ * =============================================================================
+ * SECCIÓN 3: COMPONENTES DEL SISTEMA
+ * =============================================================================
+ * Descripción del hardware y software que compone el sistema
+ * Según Art. 15.2.d) Orden HAC/1177/2024
+ */
+$declaracionResponsable['componentes'] = array(
+
+    /**
+     * Componentes de software
+     */
+    'software' => array(
+        array(
+            'nombre' => 'Dolibarr ERP/CRM',
+            'descripcion' => 'Sistema ERP/CRM de código abierto',
+            'version_minima' => '10.0',
+            'tipo' => 'plataforma_base',
+        ),
+        array(
+            'nombre' => 'PHP',
+            'descripcion' => 'Lenguaje de programación del servidor',
+            'version_minima' => '7.4',
+            'tipo' => 'runtime',
+        ),
+        array(
+            'nombre' => 'OpenSSL',
+            'descripcion' => 'Biblioteca criptográfica para firma digital',
+            'version_minima' => '1.1.0',
+            'tipo' => 'dependencia',
+        ),
+        array(
+            'nombre' => 'SOAP Extension',
+            'descripcion' => 'Extensión PHP para comunicación con servicios web AEAT',
+            'version_minima' => '',
+            'tipo' => 'dependencia',
+        ),
+        array(
+            'nombre' => 'chillerlan/php-qrcode',
+            'descripcion' => 'Biblioteca para generación de códigos QR',
+            'version_minima' => '4.0',
+            'tipo' => 'dependencia',
+        ),
+    ),
+
+    /**
+     * Requisitos de hardware (mínimos)
+     */
+    'hardware' => array(
+        'arquitectura' => 'x86_64 / ARM64',
+        'memoria_minima' => '512 MB',
+        'almacenamiento_minimo' => '100 MB',
+        'descripcion' => 'Servidor web compatible con PHP 7.4+',
+    ),
+
+    /**
+     * Funcionalidades del sistema
+     * Según especificaciones técnicas de VeriFactu
+     */
+    'funcionalidades' => array(
+        'generacion_registros' => true,
+        'encadenamiento_hash' => true,
+        'firma_electronica' => true,
+        'generacion_qr' => true,
+        'envio_aeat' => true,
+        'consulta_aeat' => true,
+        'conservacion_registros' => true,
+        'exportacion_datos' => true,
+    ),
+);
+
+/**
+ * =============================================================================
+ * SECCIÓN 4: ESPECIFICACIONES TÉCNICAS VERIFACTU
+ * =============================================================================
+ * Según Orden HAC/1177/2024, Anexos I y II
+ */
+$declaracionResponsable['especificaciones_tecnicas'] = array(
+
+    /**
+     * Modalidad de funcionamiento
+     * @required Obligatorio según Art. 15.2.e) Orden HAC/1177/2024
+     *
+     * Valores posibles:
+     * - 'verifactu': Sistema VERI*FACTU (envío inmediato a AEAT)
+     * - 'no_verifactu': Sistema NO VERI*FACTU (sin envío inmediato)
+     */
+    'modalidad_funcionamiento' => 'verifactu',
+
+    /**
+     * ¿Funciona exclusivamente como VERI*FACTU?
+     * Si es true, el sistema solo opera en modo VERI*FACTU
+     * Si es false, puede operar en ambos modos
+     */
+    'exclusivo_verifactu' => false,
+
+    /**
+     * Sistema multi-usuario
+     * Indica si permite varios obligados tributarios en la misma instalación
+     * @required Obligatorio según Art. 15.2.f) Orden HAC/1177/2024
+     */
+    'multiusuario' => true,
+
+    /**
+     * Multiempresa
+     * Indica si soporta múltiples empresas/entidades
+     */
+    'multiempresa' => true,
+
+    /**
+     * Tipo de firma electrónica utilizada
+     * @required Obligatorio según Art. 15.2.g) Orden HAC/1177/2024
+     *
+     * Según Art. 14 Orden HAC/1177/2024:
+     * - XAdES Enveloped con certificado cualificado
+     */
+    'tipo_firma' => array(
+        'formato' => 'XAdES',
+        'tipo' => 'Enveloped',
+        'nivel' => 'B-Level',
+        'certificado' => 'Certificado cualificado de firma electrónica',
+        'algoritmo_firma' => 'RSA-SHA256',
+        'algoritmo_hash' => 'SHA-256',
+    ),
+
+    /**
+     * Algoritmo de huella (hash) para encadenamiento
+     * Según Art. 14 Orden HAC/1177/2024
+     */
+    'algoritmo_huella' => 'SHA-256',
+
+    /**
+     * Codificación de caracteres
+     */
+    'codificacion' => 'UTF-8',
+
+    /**
+     * Versión del esquema XML de VeriFactu
+     */
+    'version_esquema_xml' => '1.0',
+
+    /**
+     * URLs de los servicios web de la AEAT
+     */
+    'endpoints_aeat' => array(
+        'produccion' => 'https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/tike/cont/ws/SuministroLR.wsdl',
+        'pruebas' => 'https://www7.aeat.es/wlpl/TIKE-CONT/ws/SuministroLR.wsdl',
+    ),
+);
+
+/**
+ * =============================================================================
+ * SECCIÓN 5: INTEGRIDAD DEL SISTEMA (HASH DEL MÓDULO)
+ * =============================================================================
+ * Huella digital para verificar la integridad del sistema
+ */
+$declaracionResponsable['integridad'] = array(
+
+    /**
+     * Algoritmo utilizado para el cálculo del hash
+     */
+    'algoritmo' => 'SHA-256',
+
+    /**
+     * Hash del módulo (se calcula dinámicamente)
+     * Este valor se genera automáticamente al cargar el fichero
+     */
+    'hash_modulo' => '',  // Se calcula en tiempo de ejecución
+
+    /**
+     * Fecha del último cálculo de hash
+     */
+    'fecha_calculo' => '',
+
+    /**
+     * Ficheros incluidos en el cálculo del hash
+     * Lista de ficheros críticos cuya integridad se verifica
+     */
+    'ficheros_verificados' => array(
+        'core/modules/modVerifactu.class.php',
+        'class/verifactu.class.php',
+        'class/verifactu.utils.php',
+        'lib/verifactu.lib.php',
+        'lib/verifactu-types.array.php',
+        'core/triggers/interface_99_modVerifactu_VerifactuTriggers.class.php',
+    ),
+);
+
+/**
+ * =============================================================================
+ * SECCIÓN 6: DECLARACIÓN DE CUMPLIMIENTO NORMATIVO
+ * =============================================================================
+ * Según Art. 15.3 Orden HAC/1177/2024
+ */
+$declaracionResponsable['cumplimiento'] = array(
+
+    /**
+     * Declaración responsable de cumplimiento
+     * Según artículo 29.2.j) de la Ley 58/2003, General Tributaria
+     */
+    'declaracion' => 'El productor del sistema informático de facturación declara, '
+        . 'bajo su responsabilidad, que el presente sistema cumple con los requisitos '
+        . 'establecidos en el Real Decreto 1007/2023, de 5 de diciembre, por el que se '
+        . 'aprueba el Reglamento que establece los requisitos que deben adoptar los '
+        . 'sistemas y programas informáticos o electrónicos que soporten los procesos '
+        . 'de facturación de empresarios y profesionales, y la estandarización de '
+        . 'formatos de los registros de facturación, y en la Orden HAC/1177/2024, '
+        . 'de 17 de octubre, que desarrolla las especificaciones técnicas.',
+
+    /**
+     * Requisitos técnicos cumplidos
+     * Según Art. 8 del RD 1007/2023
+     */
+    'requisitos_cumplidos' => array(
+        'integridad' => true,          // Art. 8.1.a) Integridad
+        'conservacion' => true,        // Art. 8.1.b) Conservación
+        'accesibilidad' => true,       // Art. 8.1.c) Accesibilidad
+        'legibilidad' => true,         // Art. 8.1.d) Legibilidad
+        'trazabilidad' => true,        // Art. 8.1.e) Trazabilidad
+        'inalterabilidad' => true,     // Art. 8.1.f) Inalterabilidad
+    ),
+
+    /**
+     * Referencia normativa principal
+     */
+    'referencia_legal' => array(
+        'ley' => 'Ley 58/2003, de 17 de diciembre, General Tributaria',
+        'articulo' => '29.2.j)',
+        'real_decreto' => 'Real Decreto 1007/2023, de 5 de diciembre',
+        'orden_ministerial' => 'Orden HAC/1177/2024, de 17 de octubre',
+    ),
+);
+
+/**
+ * =============================================================================
+ * SECCIÓN 7: FECHA Y LUGAR DE LA DECLARACIÓN
+ * =============================================================================
+ * Según Art. 15.4 Orden HAC/1177/2024
+ */
+$declaracionResponsable['suscripcion'] = array(
+
+    /**
+     * Fecha de suscripción de la declaración responsable
+     * Formato: YYYY-MM-DD (ISO 8601)
+     * @required Obligatorio
+     */
+    'fecha' => '2025-12-12',
+
+    /**
+     * Lugar de suscripción
+     * @required Obligatorio (localidad y país como mínimo)
+     */
+    'lugar' => array(
+        'localidad' => '',
+        'provincia' => '',
+        'pais' => 'España',
+        'codigo_pais' => 'ES',
+    ),
+
+    /**
+     * Persona que suscribe la declaración
+     */
+    'firmante' => array(
+        'nombre' => 'Germán Luis Aracil Boned',
+        'cargo' => 'Desarrollador / Productor',
+        'en_representacion_de' => '',  // Si actúa en representación de una entidad
+    ),
+);
+
+/**
+ * =============================================================================
+ * SECCIÓN 8: METADATOS DE LA CONFIGURACIÓN
+ * =============================================================================
+ */
+$declaracionResponsable['metadata'] = array(
+
+    /**
+     * Versión del fichero de configuración
+     */
+    'version_config' => '1.0.0',
+
+    /**
+     * Fecha de creación
+     */
+    'fecha_creacion' => '2025-12-12',
+
+    /**
+     * Última modificación
+     */
+    'ultima_modificacion' => '2025-12-12',
+
+    /**
+     * Autor de la configuración
+     */
+    'autor' => 'Germán Luis Aracil Boned',
+
+    /**
+     * Notas de la versión
+     */
+    'notas' => 'Versión inicial del fichero de configuración para declaración responsable.',
+);
+
+/**
+ * =============================================================================
+ * FUNCIONES AUXILIARES
+ * =============================================================================
+ */
+
+/**
+ * Calcula el hash de integridad del módulo VeriFactu
+ *
+ * @param string $basePath Ruta base del módulo
+ * @return string Hash SHA-256 del módulo
+ */
+function calcularHashModuloVerifactu($basePath = '')
+{
+    global $declaracionResponsable;
+
+    if (empty($basePath)) {
+        $basePath = dirname(__DIR__);
+    }
+
+    $contenidoTotal = '';
+
+    foreach ($declaracionResponsable['integridad']['ficheros_verificados'] as $fichero) {
+        $rutaCompleta = $basePath . '/' . $fichero;
+        if (file_exists($rutaCompleta)) {
+            $contenidoTotal .= file_get_contents($rutaCompleta);
+        }
+    }
+
+    $hash = hash('sha256', $contenidoTotal);
+
+    // Actualizar valores en la configuración
+    $declaracionResponsable['integridad']['hash_modulo'] = $hash;
+    $declaracionResponsable['integridad']['fecha_calculo'] = date('Y-m-d H:i:s');
+
+    return $hash;
+}
+
+/**
+ * Genera el identificador único de instalación
+ *
+ * @return string Identificador único
+ */
+function generarIdInstalacion()
+{
+    global $declaracionResponsable, $conf;
+
+    $datos = array(
+        $declaracionResponsable['sistema']['id_sistema_informatico'],
+        $declaracionResponsable['sistema']['version'],
+        isset($conf->global->MAIN_INFO_SOCIETE_NOM) ? $conf->global->MAIN_INFO_SOCIETE_NOM : '',
+        isset($conf->global->MAIN_INFO_SIREN) ? $conf->global->MAIN_INFO_SIREN : '',
+        php_uname('n'),
+    );
+
+    return substr(hash('sha256', implode('|', $datos)), 0, 32);
+}
+
+/**
+ * Obtiene la configuración completa de la declaración responsable
+ *
+ * @param bool $calcularHash Si es true, recalcula el hash del módulo
+ * @return array Configuración completa
+ */
+function obtenerDeclaracionResponsable($calcularHash = true)
+{
+    global $declaracionResponsable;
+
+    if ($calcularHash) {
+        calcularHashModuloVerifactu();
+    }
+
+    $declaracionResponsable['sistema']['numero_instalacion'] = generarIdInstalacion();
+
+    return $declaracionResponsable;
+}
+
+/**
+ * Valida que la configuración de la declaración responsable esté completa
+ *
+ * @return array Array con errores encontrados (vacío si todo es correcto)
+ */
+function validarDeclaracionResponsable()
+{
+    global $declaracionResponsable;
+
+    $errores = array();
+
+    // Validar datos del productor
+    if (empty($declaracionResponsable['productor']['razon_social'])) {
+        $errores[] = 'Falta la razón social del productor';
+    }
+    if (empty($declaracionResponsable['productor']['nif']) &&
+        empty($declaracionResponsable['productor']['nif_extranjero']['numero'])) {
+        $errores[] = 'Falta el NIF o identificación fiscal del productor';
+    }
+    if (empty($declaracionResponsable['productor']['direccion']['localidad'])) {
+        $errores[] = 'Falta la localidad en la dirección del productor';
+    }
+
+    // Validar datos del sistema
+    if (empty($declaracionResponsable['sistema']['nombre'])) {
+        $errores[] = 'Falta el nombre del sistema informático';
+    }
+    if (empty($declaracionResponsable['sistema']['id_sistema_informatico'])) {
+        $errores[] = 'Falta el IdSistemaInformatico';
+    }
+    if (empty($declaracionResponsable['sistema']['version'])) {
+        $errores[] = 'Falta la versión del sistema';
+    }
+
+    // Validar suscripción
+    if (empty($declaracionResponsable['suscripcion']['fecha'])) {
+        $errores[] = 'Falta la fecha de suscripción';
+    }
+    if (empty($declaracionResponsable['suscripcion']['lugar']['localidad'])) {
+        $errores[] = 'Falta la localidad de suscripción';
+    }
+
+    return $errores;
+}
+
+/**
+ * Exporta la declaración responsable en formato JSON
+ *
+ * @return string JSON de la declaración
+ */
+function exportarDeclaracionJSON()
+{
+    $declaracion = obtenerDeclaracionResponsable(true);
+    return json_encode($declaracion, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+}

--- a/docs/declaracion_responsable.md
+++ b/docs/declaracion_responsable.md
@@ -1,0 +1,350 @@
+# Configuración de la Declaración Responsable VeriFactu
+
+## Introducción
+
+Este documento describe cómo configurar y utilizar el fichero de configuración de la Declaración Responsable para el módulo VeriFactu de Dolibarr.
+
+La Declaración Responsable es un requisito legal establecido por la normativa española para todos los productores de sistemas informáticos de facturación.
+
+## Marco Legal
+
+El fichero de configuración cumple con la siguiente normativa:
+
+| Normativa | Descripción |
+|-----------|-------------|
+| **RD 1007/2023** | Reglamento VeriFactu - Requisitos para sistemas de facturación |
+| **RD 254/2025** | Modificaciones y plazos de implementación |
+| **Orden HAC/1177/2024** | Especificaciones técnicas y funcionales |
+| **Art. 29.2.j) Ley 58/2003** | Ley General Tributaria |
+
+## Ubicación del Fichero
+
+```
+verifactu/
+└── conf/
+    └── declaracion_responsable.conf.php
+```
+
+## Estructura del Fichero
+
+El fichero de configuración está organizado en 8 secciones principales:
+
+### 1. Datos del Productor (`$declaracionResponsable['productor']`)
+
+Datos de la persona o entidad que desarrolla el sistema informático.
+
+```php
+$declaracionResponsable['productor'] = array(
+    'razon_social' => 'Nombre del productor',
+    'nif' => 'NIF español',
+    'nif_extranjero' => array(
+        'tipo_identificacion' => '',
+        'numero' => '',
+        'pais_emision' => '',
+    ),
+    'direccion' => array(
+        'tipo_via' => 'Calle',
+        'nombre_via' => '',
+        'numero' => '',
+        'codigo_postal' => '',
+        'localidad' => '',
+        'provincia' => '',
+        'pais' => 'España',
+    ),
+    'contacto' => array(
+        'email' => '',
+        'telefono' => '',
+        'web' => '',
+    ),
+);
+```
+
+**Campos obligatorios:**
+- `razon_social`: Nombre completo o razón social
+- `nif` o `nif_extranjero`: Identificación fiscal
+- `direccion.localidad`: Localidad del productor
+
+### 2. Datos del Sistema (`$declaracionResponsable['sistema']`)
+
+Información del sistema informático de facturación.
+
+```php
+$declaracionResponsable['sistema'] = array(
+    'nombre' => 'VeriFactu para Dolibarr ERP/CRM',
+    'id_sistema_informatico' => 'VERIFACTU-DOLIBARR-OSS',
+    'version' => '1.0.2',
+    'fecha_version' => '2025-07-16',
+    'tipo_licencia' => 'GPL-3.0-or-later',
+);
+```
+
+**Campos obligatorios:**
+- `nombre`: Nombre comercial del sistema
+- `id_sistema_informatico`: Código único identificador (máx. 30 caracteres)
+- `version`: Versión del sistema
+
+### 3. Componentes (`$declaracionResponsable['componentes']`)
+
+Descripción del hardware y software que compone el sistema.
+
+```php
+$declaracionResponsable['componentes'] = array(
+    'software' => array(
+        array(
+            'nombre' => 'Dolibarr ERP/CRM',
+            'descripcion' => 'Sistema ERP/CRM de código abierto',
+            'version_minima' => '10.0',
+            'tipo' => 'plataforma_base',
+        ),
+        // ... más componentes
+    ),
+    'hardware' => array(
+        'arquitectura' => 'x86_64 / ARM64',
+        'memoria_minima' => '512 MB',
+    ),
+    'funcionalidades' => array(
+        'generacion_registros' => true,
+        'encadenamiento_hash' => true,
+        'firma_electronica' => true,
+        // ... más funcionalidades
+    ),
+);
+```
+
+### 4. Especificaciones Técnicas (`$declaracionResponsable['especificaciones_tecnicas']`)
+
+Configuración técnica del sistema VeriFactu.
+
+```php
+$declaracionResponsable['especificaciones_tecnicas'] = array(
+    'modalidad_funcionamiento' => 'verifactu', // 'verifactu' o 'no_verifactu'
+    'exclusivo_verifactu' => false,
+    'multiusuario' => true,
+    'multiempresa' => true,
+    'tipo_firma' => array(
+        'formato' => 'XAdES',
+        'tipo' => 'Enveloped',
+        'algoritmo_firma' => 'RSA-SHA256',
+        'algoritmo_hash' => 'SHA-256',
+    ),
+    'algoritmo_huella' => 'SHA-256',
+);
+```
+
+### 5. Integridad (`$declaracionResponsable['integridad']`)
+
+Configuración para el cálculo del hash de integridad del módulo.
+
+```php
+$declaracionResponsable['integridad'] = array(
+    'algoritmo' => 'SHA-256',
+    'hash_modulo' => '',  // Se calcula automáticamente
+    'fecha_calculo' => '',
+    'ficheros_verificados' => array(
+        'core/modules/modVerifactu.class.php',
+        'class/verifactu.class.php',
+        // ... ficheros críticos
+    ),
+);
+```
+
+### 6. Cumplimiento (`$declaracionResponsable['cumplimiento']`)
+
+Declaración de cumplimiento normativo.
+
+```php
+$declaracionResponsable['cumplimiento'] = array(
+    'declaracion' => 'Texto de la declaración responsable...',
+    'requisitos_cumplidos' => array(
+        'integridad' => true,
+        'conservacion' => true,
+        'accesibilidad' => true,
+        'legibilidad' => true,
+        'trazabilidad' => true,
+        'inalterabilidad' => true,
+    ),
+    'referencia_legal' => array(
+        'ley' => 'Ley 58/2003',
+        'real_decreto' => 'Real Decreto 1007/2023',
+        'orden_ministerial' => 'Orden HAC/1177/2024',
+    ),
+);
+```
+
+### 7. Suscripción (`$declaracionResponsable['suscripcion']`)
+
+Fecha y lugar de la declaración.
+
+```php
+$declaracionResponsable['suscripcion'] = array(
+    'fecha' => '2025-12-12',  // Formato YYYY-MM-DD
+    'lugar' => array(
+        'localidad' => 'Madrid',
+        'provincia' => 'Madrid',
+        'pais' => 'España',
+    ),
+    'firmante' => array(
+        'nombre' => 'Nombre del firmante',
+        'cargo' => 'Desarrollador / Productor',
+    ),
+);
+```
+
+### 8. Metadatos (`$declaracionResponsable['metadata']`)
+
+Información sobre el fichero de configuración.
+
+```php
+$declaracionResponsable['metadata'] = array(
+    'version_config' => '1.0.0',
+    'fecha_creacion' => '2025-12-12',
+    'ultima_modificacion' => '2025-12-12',
+    'autor' => 'Nombre del autor',
+);
+```
+
+## Uso del Fichero
+
+### Cargar la Configuración
+
+```php
+// Incluir el fichero de configuración
+$confFile = dol_buildpath('/verifactu/conf/declaracion_responsable.conf.php', 0);
+require_once $confFile;
+
+// Obtener la configuración completa (calcula el hash automáticamente)
+$declaracion = obtenerDeclaracionResponsable(true);
+
+// Validar la configuración
+$errores = validarDeclaracionResponsable();
+if (!empty($errores)) {
+    foreach ($errores as $error) {
+        echo "Error: " . $error . "\n";
+    }
+}
+```
+
+### Funciones Disponibles
+
+| Función | Descripción |
+|---------|-------------|
+| `obtenerDeclaracionResponsable($calcularHash)` | Obtiene la configuración completa. Si `$calcularHash` es true, recalcula el hash de integridad. |
+| `validarDeclaracionResponsable()` | Valida que los campos obligatorios estén completos. Devuelve array de errores. |
+| `calcularHashModuloVerifactu($basePath)` | Calcula el hash SHA-256 de los ficheros críticos del módulo. |
+| `generarIdInstalacion()` | Genera un identificador único para la instalación. |
+| `exportarDeclaracionJSON()` | Exporta la declaración en formato JSON. |
+
+### Ejemplo: Obtener Hash del Módulo
+
+```php
+require_once dol_buildpath('/verifactu/conf/declaracion_responsable.conf.php', 0);
+
+$hash = calcularHashModuloVerifactu();
+echo "Hash del módulo: " . $hash;
+```
+
+### Ejemplo: Exportar a JSON
+
+```php
+require_once dol_buildpath('/verifactu/conf/declaracion_responsable.conf.php', 0);
+
+$json = exportarDeclaracionJSON();
+file_put_contents('/tmp/declaracion.json', $json);
+```
+
+## Configuración Inicial
+
+Para configurar la declaración responsable, siga estos pasos:
+
+1. **Editar el fichero de configuración:**
+   ```bash
+   nano conf/declaracion_responsable.conf.php
+   ```
+
+2. **Completar los datos obligatorios:**
+   - Razón social del productor
+   - NIF o identificación fiscal
+   - Dirección completa
+   - Localidad de suscripción
+
+3. **Verificar la configuración:**
+   Acceda a la página de Declaración Responsable en el menú de VeriFactu para ver los datos configurados y cualquier error de validación.
+
+4. **Exportar la declaración:**
+   Use el botón "Exportar JSON" para obtener una copia de la declaración en formato JSON.
+
+## Visualización
+
+La declaración responsable se puede visualizar en:
+
+**Menú:** VeriFactu > Declaración Responsable
+
+La página muestra:
+- Datos del productor
+- Datos del sistema informático
+- Especificaciones técnicas
+- Hash de integridad del módulo
+- Requisitos cumplidos
+- Datos de suscripción
+
+## Exportación
+
+### Formatos Disponibles
+
+| Formato | Descripción | Uso |
+|---------|-------------|-----|
+| **Imprimir** | Versión imprimible de la declaración | Documentación física |
+| **JSON** | Exportación estructurada | Integración con otros sistemas |
+
+### Endpoint JSON
+
+```
+GET /verifactu/views/declaration_json.php
+```
+
+Requiere autenticación y permisos de gestión de VeriFactu.
+
+## Hash de Integridad
+
+El hash de integridad se calcula sobre los siguientes ficheros críticos:
+
+- `core/modules/modVerifactu.class.php`
+- `class/verifactu.class.php`
+- `class/verifactu.utils.php`
+- `lib/verifactu.lib.php`
+- `lib/verifactu-types.array.php`
+- `core/triggers/interface_99_modVerifactu_VerifactuTriggers.class.php`
+
+El hash se recalcula cada vez que se accede a la página de declaración responsable, garantizando que cualquier modificación en los ficheros críticos sea detectada.
+
+## Preguntas Frecuentes
+
+### ¿Quién debe completar esta configuración?
+
+El productor o desarrollador del sistema informático. Si usted es usuario final y utiliza este módulo sin modificaciones, los datos del productor original (mantenedor del repositorio) son los que aplican.
+
+### ¿Qué pasa si no completo el NIF?
+
+La página de declaración responsable mostrará una advertencia indicando que la configuración está incompleta. Sin embargo, el módulo seguirá funcionando.
+
+### ¿Cómo se calcula el hash de integridad?
+
+Se concatena el contenido de todos los ficheros críticos y se calcula el hash SHA-256 del resultado.
+
+### ¿Puedo añadir más ficheros al cálculo del hash?
+
+Sí, puede añadir ficheros al array `ficheros_verificados` en la sección de integridad.
+
+### ¿Debo actualizar la fecha de suscripción?
+
+La fecha de suscripción debe actualizarse cuando se realicen cambios significativos en el sistema o cuando se publique una nueva versión.
+
+## Referencias
+
+- [BOE - Orden HAC/1177/2024](https://www.boe.es/diario_boe/txt.php?id=BOE-A-2024-22138)
+- [AEAT - Sistemas VeriFactu](https://sede.agenciatributaria.gob.es/Sede/iva/sistemas-informaticos-facturacion-verifactu/)
+- [FAQ AEAT - Declaración Responsable](https://sede.agenciatributaria.gob.es/Sede/iva/sistemas-informaticos-facturacion-verifactu/preguntas-frecuentes/certificacion-sistemas-informaticos-declaracion-responsable.html)
+
+---
+
+*Última actualización: 2025-12-12*

--- a/views/declaration_json.php
+++ b/views/declaration_json.php
@@ -1,0 +1,104 @@
+<?php
+/* Copyright (C) 2025 Germán Luis Aracil Boned <garacilb@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ *	\file       verifactu/views/declaration_json.php
+ *	\ingroup    verifactu
+ *	\brief      JSON export endpoint for responsible declaration
+ */
+
+// Load Dolibarr environment
+$res = 0;
+if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
+	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"] . "/main.inc.php";
+}
+$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME'];
+$tmp2 = realpath(__FILE__);
+$i = strlen($tmp) - 1;
+$j = strlen($tmp2) - 1;
+while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
+	$i--;
+	$j--;
+}
+if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1)) . "/main.inc.php")) {
+	$res = @include substr($tmp, 0, ($i + 1)) . "/main.inc.php";
+}
+if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1))) . "/main.inc.php")) {
+	$res = @include dirname(substr($tmp, 0, ($i + 1))) . "/main.inc.php";
+}
+if (!$res && file_exists("../../main.inc.php")) {
+	$res = @include "../../main.inc.php";
+}
+if (!$res && file_exists("../../../main.inc.php")) {
+	$res = @include "../../../main.inc.php";
+}
+if (!$res) {
+	http_response_code(500);
+	header('Content-Type: application/json');
+	echo json_encode(['error' => 'Include of main fails']);
+	exit;
+}
+
+// Security check - require login
+if (empty($user->id)) {
+	http_response_code(401);
+	header('Content-Type: application/json');
+	echo json_encode(['error' => 'Authentication required']);
+	exit;
+}
+
+// Check permissions
+if (!$user->admin && empty($user->rights->verifactu->manage)) {
+	http_response_code(403);
+	header('Content-Type: application/json');
+	echo json_encode(['error' => 'Permission denied']);
+	exit;
+}
+
+// Load configuration file
+$confFile = dol_buildpath('/verifactu/conf/declaracion_responsable.conf.php', 0);
+if (!file_exists($confFile)) {
+	http_response_code(404);
+	header('Content-Type: application/json');
+	echo json_encode(['error' => 'Configuration file not found']);
+	exit;
+}
+
+require_once $confFile;
+
+// Get declaration data with hash calculation
+$declaracion = obtenerDeclaracionResponsable(true);
+
+// Add export metadata
+$declaracion['export_metadata'] = array(
+	'export_date' => date('Y-m-d H:i:s'),
+	'export_user' => $user->login,
+	'export_format' => 'JSON',
+	'dolibarr_version' => DOL_VERSION,
+	'php_version' => PHP_VERSION,
+);
+
+// Set headers for JSON download
+$filename = 'declaracion_responsable_verifactu_' . date('Ymd_His') . '.json';
+header('Content-Type: application/json; charset=utf-8');
+header('Content-Disposition: attachment; filename="' . $filename . '"');
+header('Cache-Control: no-cache, no-store, must-revalidate');
+header('Pragma: no-cache');
+header('Expires: 0');
+
+// Output JSON
+echo json_encode($declaracion, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);


### PR DESCRIPTION
- Create conf/declaracion_responsable.conf.php with all required fields per Orden HAC/1177/2024 and RD 1007/2023:
  - Producer data (NIF, address, contact)
  - System information (name, ID, version)
  - Technical specifications (signature type, hash algorithm)
  - Module integrity hash calculation (SHA-256)
  - Compliance declaration with legal references

- Update views/declaration.php to use the configuration file
  - Dynamic display of all declaration fields
  - Configuration validation with error messages
  - Hash of module displayed for integrity verification

- Add views/declaration_json.php endpoint for JSON export
  - Authenticated access required
  - Includes export metadata

- Add docs/declaracion_responsable.md with usage documentation
  - Configuration structure explanation
  - Available functions
  - FAQ section