### PR TITLE
fix: add legacy Spanish extrafield key aliases to all language files

### DIFF
--- a/langs/ca_ES/verifactu.lang
+++ b/langs/ca_ES/verifactu.lang
@@ -571,4 +571,40 @@ VERIFACTU_SCHEMAS_NOT_DOWNLOADED = No descargados
 VERIFACTU_SCHEMAS_LAST_DOWNLOAD = Última descarga
 VERIFACTU_SCHEMAS_DOWNLOAD_BUTTON = Descargar/Actualizar esquemas
 VERIFACTU_SCHEMAS_DOWNLOAD_SUCCESS = Esquemas descargados correctamente (%s archivos)
-VERIFACTU_SCHEMAS_DOWNLOAD_ERROR = Error al descargar esquemas: %s
+VERIFACTU_SCHEMAS_DOWNLOAD_ERROR = Error al descarregar esquemes: %s
+
+# Legacy key aliases (old Spanish extrafield labels stored in DB from original installations)
+verifactu_INICIO_Separador1 = <span class="badge badge-status1 badge-status">Dades VeriFactu</span><span class="classfortooltip" style="padding: 0px; padding-right: 3px !important;" title="Estat de la factura a VeriFactu"><span class="fas fa-info-circle em088 opacityhigh" style="vertical-align: middle; cursor: help"></span></span>
+verifactu_INICIO_Separador2 = <span class="badge badge-status1 badge-status">CAMPS FISCALS ⚠️</span><span class="classfortooltip" style="padding: 0px; padding-right: 3px !important;" title="⚠️ IMPORTANT: Impost, Clau Règim, Qualificació i Operació Exempta són responsabilitat de l'empresa. Consulteu amb el vostre assessor fiscal en cas de dubte."><span class="fas fa-info-circle em088 opacityhigh" style="vertical-align: middle; cursor: help"></span></span>
+verifactu_ESTADO = Estat
+verifactu_ESTADOTooltip = Estat de la factura a VeriFactu
+verifactu_CSV_Factura = Codi CSV
+verifactu_CSV_FacturaTooltip = Codi de verificació de l'AEAT. Si no existeix, la factura no s'ha enviat.
+verifactu_ID_Factura = ID a VeriFactu
+verifactu_ID_FacturaTooltip = Identificador de la factura a VeriFactu
+verifactu_FECHA_Factura = Data d'emissió
+verifactu_FECHA_FacturaTooltip = Data d'emissió registrada a VeriFactu
+verifactu_ULTIMA_salida = Última resposta
+verifactu_ULTIMA_salidaTooltip = Última resposta de VeriFactu
+verifactu_ULTIMAFECHA_Modificacion = Última modificació
+verifactu_ULTIMAFECHA_ModificacionTooltip = Data d'última modificació a VeriFactu
+verifactu_HUELLA = Empremta digital
+verifactu_HUELLATooltip = Empremta SHA-256 de la factura
+verifactu_FECHA_HORA_Generacion = Data/hora d'empremta
+verifactu_FECHA_HORA_GeneracionTooltip = Data i hora de generació de l'empremta (ISO 8601)
+VERIFACTU_entorno = Entorn (proves/producció)
+VERIFACTU_entornoTooltip = Entorn en el qual es va enviar la factura a VeriFactu
+VERIFACTU_modo = Mode d'operació
+VERIFACTU_modoTooltip = Mode d'operació VeriFactu
+verifactu_Factura_Tipo = Tipus de factura
+verifactu_Factura_TipoTooltip = Tipus de factura per a VeriFactu
+verifactu_IMPUESTO = Impost
+verifactu_IMPUESTOTooltip = Tipus d'impost aplicable. Per defecte IVA. Necessari per a la tipologia de factura.
+verifactu_CLAVE_Regimen = Clau Règim
+verifactu_CLAVE_RegimenTooltip = Clau del règim especial. Només aplicable per a IVA o IGIC, no per a IPSI o ALTRES.
+verifactu_CALIFICACION_Operacion = Qualificació Operació
+verifactu_CALIFICACION_OperacionTooltip = Clau d'operació subjecta/no exempta o no subjecta. S1=Sense inversió, S2=Amb inversió, N1=No subjecta art.7,14, N2=No subjecta localització.
+verifactu_OPERACION_Exenta = Operació Exempta
+verifactu_OPERACION_ExentaTooltip = Tipus d'exempció (E1-E6) quan l'operació està exempta d'IVA/IGIC/IPSI.
+verifactu_INCIDENCIA = Incidència
+verifactu_INCIDENCIATooltip = Indica si hi va haver incidència tècnica (sense electricitat, sense internet, fallada del sistema). Per defecte "N".

--- a/langs/en_US/verifactu.lang
+++ b/langs/en_US/verifactu.lang
@@ -682,3 +682,39 @@ VERIFACTU_SCHEMAS_LAST_DOWNLOAD = Last download
 VERIFACTU_SCHEMAS_DOWNLOAD_BUTTON = Download/Update schemas
 VERIFACTU_SCHEMAS_DOWNLOAD_SUCCESS = Schemas downloaded successfully (%s files)
 VERIFACTU_SCHEMAS_DOWNLOAD_ERROR = Error downloading schemas: %s
+
+# Legacy key aliases (old Spanish extrafield labels stored in DB from original installations)
+verifactu_INICIO_Separador1 = <span class="badge badge-status1 badge-status">VeriFactu Data</span><span class="classfortooltip" style="padding: 0px; padding-right: 3px !important;" title="Invoice status in VeriFactu"><span class="fas fa-info-circle em088 opacityhigh" style="vertical-align: middle; cursor: help"></span></span>
+verifactu_INICIO_Separador2 = <span class="badge badge-status1 badge-status">TAX FIELDS ⚠️</span><span class="classfortooltip" style="padding: 0px; padding-right: 3px !important;" title="⚠️ IMPORTANT: Tax, Regime Key, Classification and Exempt Operation are company responsibility. Consult your tax advisor if in doubt."><span class="fas fa-info-circle em088 opacityhigh" style="vertical-align: middle; cursor: help"></span></span>
+verifactu_ESTADO = Status
+verifactu_ESTADOTooltip = Invoice status in VeriFactu
+verifactu_CSV_Factura = CSV Code
+verifactu_CSV_FacturaTooltip = AEAT verification code. If missing, invoice hasn't been sent.
+verifactu_ID_Factura = VeriFactu ID
+verifactu_ID_FacturaTooltip = Invoice identifier in VeriFactu
+verifactu_FECHA_Factura = Issue date
+verifactu_FECHA_FacturaTooltip = Issue date registered in VeriFactu
+verifactu_ULTIMA_salida = Last response
+verifactu_ULTIMA_salidaTooltip = Last VeriFactu response
+verifactu_ULTIMAFECHA_Modificacion = Last modification
+verifactu_ULTIMAFECHA_ModificacionTooltip = Last modification date in VeriFactu
+verifactu_HUELLA = Digital fingerprint
+verifactu_HUELLATooltip = SHA-256 fingerprint of the invoice
+verifactu_FECHA_HORA_Generacion = Fingerprint date/time
+verifactu_FECHA_HORA_GeneracionTooltip = Fingerprint generation date and time (ISO 8601)
+VERIFACTU_entorno = Environment (Test/Production)
+VERIFACTU_entornoTooltip = Environment in which the invoice was sent to VeriFactu
+VERIFACTU_modo = Operation Mode
+VERIFACTU_modoTooltip = VeriFactu operation mode
+verifactu_Factura_Tipo = Invoice type
+verifactu_Factura_TipoTooltip = Invoice type for VeriFactu
+verifactu_IMPUESTO = Tax
+verifactu_IMPUESTOTooltip = Applicable tax type. Defaults to VAT. Required for invoice typology.
+verifactu_CLAVE_Regimen = Regime Key
+verifactu_CLAVE_RegimenTooltip = Special regime key. Only for VAT or IGIC, not for IPSI or OTHERS.
+verifactu_CALIFICACION_Operacion = Operation Classification
+verifactu_CALIFICACION_OperacionTooltip = Taxable/non-exempt or non-taxable operation key. S1=No reversal, S2=With reversal, N1=Non-taxable art.7,14, N2=Non-taxable location.
+verifactu_OPERACION_Exenta = Exempt Operation
+verifactu_OPERACION_ExentaTooltip = Exemption type (E1-E6) when operation is VAT/IGIC/IPSI exempt.
+verifactu_INCIDENCIA = Incident
+verifactu_INCIDENCIATooltip = Indicates technical incident (no electricity, no internet, system failure). Defaults to "N".

--- a/langs/es_ES/verifactu.lang
+++ b/langs/es_ES/verifactu.lang
@@ -682,3 +682,39 @@ VERIFACTU_SCHEMAS_LAST_DOWNLOAD = Última descarga
 VERIFACTU_SCHEMAS_DOWNLOAD_BUTTON = Descargar/Actualizar esquemas
 VERIFACTU_SCHEMAS_DOWNLOAD_SUCCESS = Esquemas descargados correctamente (%s archivos)
 VERIFACTU_SCHEMAS_DOWNLOAD_ERROR = Error al descargar esquemas: %s
+
+# Legacy key aliases (old Spanish extrafield labels stored in DB from original installations)
+verifactu_INICIO_Separador1 = <span class="badge badge-status1 badge-status">Datos VeriFactu</span><span class="classfortooltip" style="padding: 0px; padding-right: 3px !important;" title="Estado de la factura en VeriFactu"><span class="fas fa-info-circle em088 opacityhigh" style="vertical-align: middle; cursor: help"></span></span>
+verifactu_INICIO_Separador2 = <span class="badge badge-status1 badge-status">CAMPOS FISCALES ⚠️</span><span class="classfortooltip" style="padding: 0px; padding-right: 3px !important;" title="⚠️ IMPORTANTE: Impuesto, Clave Régimen, Calificación y Operación Exenta son responsabilidad de la empresa. Consulte con su asesor fiscal en caso de duda."><span class="fas fa-info-circle em088 opacityhigh" style="vertical-align: middle; cursor: help"></span></span>
+verifactu_ESTADO = Estado
+verifactu_ESTADOTooltip = Estado de la factura en VeriFactu
+verifactu_CSV_Factura = Código CSV
+verifactu_CSV_FacturaTooltip = Código de verificación de AEAT. Si no existe, la factura no ha sido enviada.
+verifactu_ID_Factura = ID en VeriFactu
+verifactu_ID_FacturaTooltip = Identificador de la factura en VeriFactu
+verifactu_FECHA_Factura = Fecha de emisión
+verifactu_FECHA_FacturaTooltip = Fecha de emisión registrada en VeriFactu
+verifactu_ULTIMA_salida = Última respuesta
+verifactu_ULTIMA_salidaTooltip = Última respuesta de VeriFactu
+verifactu_ULTIMAFECHA_Modificacion = Última modificación
+verifactu_ULTIMAFECHA_ModificacionTooltip = Fecha de última modificación en VeriFactu
+verifactu_HUELLA = Huella digital
+verifactu_HUELLATooltip = Huella SHA-256 de la factura
+verifactu_FECHA_HORA_Generacion = Fecha/hora de huella
+verifactu_FECHA_HORA_GeneracionTooltip = Fecha y hora de generación de la huella (ISO 8601)
+VERIFACTU_entorno = Entorno (pruebas/producción)
+VERIFACTU_entornoTooltip = Entorno en el que se envió la factura a VeriFactu
+VERIFACTU_modo = Modo de operación
+VERIFACTU_modoTooltip = Modo de operación VeriFactu
+verifactu_Factura_Tipo = Tipo de factura
+verifactu_Factura_TipoTooltip = Tipo de factura para VeriFactu
+verifactu_IMPUESTO = Impuesto
+verifactu_IMPUESTOTooltip = Tipo de impuesto aplicable. Por defecto IVA. Necesario para la tipología de factura.
+verifactu_CLAVE_Regimen = Clave Régimen
+verifactu_CLAVE_RegimenTooltip = Clave del régimen especial. Solo aplicable para IVA o IGIC, no para IPSI u OTROS.
+verifactu_CALIFICACION_Operacion = Calificación Operación
+verifactu_CALIFICACION_OperacionTooltip = Clave de operación sujeta/no exenta o no sujeta. S1=Sin inversión, S2=Con inversión, N1=No sujeta art.7,14, N2=No sujeta localización.
+verifactu_OPERACION_Exenta = Operación Exenta
+verifactu_OPERACION_ExentaTooltip = Tipo de exención (E1-E6) cuando la operación está exenta de IVA/IGIC/IPSI.
+verifactu_INCIDENCIA = Incidencia
+verifactu_INCIDENCIATooltip = Indica si hubo incidencia técnica (sin electricidad, sin internet, fallo del sistema). Por defecto "N".

--- a/langs/eu_ES/verifactu.lang
+++ b/langs/eu_ES/verifactu.lang
@@ -571,4 +571,40 @@ VERIFACTU_SCHEMAS_NOT_DOWNLOADED = No descargados
 VERIFACTU_SCHEMAS_LAST_DOWNLOAD = Última descarga
 VERIFACTU_SCHEMAS_DOWNLOAD_BUTTON = Descargar/Actualizar esquemas
 VERIFACTU_SCHEMAS_DOWNLOAD_SUCCESS = Esquemas descargados correctamente (%s archivos)
-VERIFACTU_SCHEMAS_DOWNLOAD_ERROR = Error al descargar esquemas: %s
+VERIFACTU_SCHEMAS_DOWNLOAD_ERROR = Eskemak deskargatzean errorea: %s
+
+# Legacy key aliases (old Spanish extrafield labels stored in DB from original installations)
+verifactu_INICIO_Separador1 = <span class="badge badge-status1 badge-status">VeriFactu Datuak</span><span class="classfortooltip" style="padding: 0px; padding-right: 3px !important;" title="Fakturaren egoera VeriFactu-n"><span class="fas fa-info-circle em088 opacityhigh" style="vertical-align: middle; cursor: help"></span></span>
+verifactu_INICIO_Separador2 = <span class="badge badge-status1 badge-status">EREMU FISKALAK ⚠️</span><span class="classfortooltip" style="padding: 0px; padding-right: 3px !important;" title="⚠️ GARRANTZITSUA: Zerga, Erregimen Gakoa, Kalifikazioa eta Eragiketa Salbuetsiak enpresaren erantzukizuna dira. Kontsultatu zure zerga aholkulariarekin zalantzarik izanez gero."><span class="fas fa-info-circle em088 opacityhigh" style="vertical-align: middle; cursor: help"></span></span>
+verifactu_ESTADO = Egoera
+verifactu_ESTADOTooltip = Fakturaren egoera VeriFactu-n
+verifactu_CSV_Factura = CSV Kodea
+verifactu_CSV_FacturaTooltip = AEATen egiaztapen kodea. Ez badago, faktura ez da bidali.
+verifactu_ID_Factura = ID VeriFactu-n
+verifactu_ID_FacturaTooltip = Fakturaren identifikatzailea VeriFactu-n
+verifactu_FECHA_Factura = Jaulkipen data
+verifactu_FECHA_FacturaTooltip = VeriFactu-n erregistratutako jaulkipen data
+verifactu_ULTIMA_salida = Azken erantzuna
+verifactu_ULTIMA_salidaTooltip = VeriFactu-ren azken erantzuna
+verifactu_ULTIMAFECHA_Modificacion = Azken aldaketa
+verifactu_ULTIMAFECHA_ModificacionTooltip = VeriFactu-n azken aldaketa data
+verifactu_HUELLA = Hatz-marka digitala
+verifactu_HUELLATooltip = Fakturaren SHA-256 hatz-marka
+verifactu_FECHA_HORA_Generacion = Hatz-markaren data/ordua
+verifactu_FECHA_HORA_GeneracionTooltip = Hatz-markaren sorrera data eta ordua (ISO 8601)
+VERIFACTU_entorno = Ingurunea (probak/produkzioa)
+VERIFACTU_entornoTooltip = Faktura VeriFactu-ra bidali zen ingurunea
+VERIFACTU_modo = Funtzionamendu modua
+VERIFACTU_modoTooltip = VeriFactu funtzionamendu modua
+verifactu_Factura_Tipo = Faktura mota
+verifactu_Factura_TipoTooltip = VeriFactu-rako faktura mota
+verifactu_IMPUESTO = Zerga
+verifactu_IMPUESTOTooltip = Aplikagarria den zerga mota. Lehenetsita BEZ. Faktura tipologiarako beharrezkoa.
+verifactu_CLAVE_Regimen = Erregimen Gakoa
+verifactu_CLAVE_RegimenTooltip = Erregimen bereziko gakoa. BEZ edo IGIC-rako soilik, ez IPSI edo BESTEentzat.
+verifactu_CALIFICACION_Operacion = Eragiketaren Kalifikazioa
+verifactu_CALIFICACION_OperacionTooltip = Eragiketa zerga-peko/ez salbuetsi edo ez zerga-peko gakoa. S1=Alderantziketa gabe, S2=Alderantziketarekin, N1=Ez zerga-pekoa 7,14 art., N2=Ez zerga-pekoa kokapenagatik.
+verifactu_OPERACION_Exenta = Eragiketa Salbuetsia
+verifactu_OPERACION_ExentaTooltip = Salbueste mota (E1-E6) eragiketa BEZ/IGIC/IPSI-tik salbuetsita dagoenean.
+verifactu_INCIDENCIA = Intzidentzia
+verifactu_INCIDENCIATooltip = Intzidentzia teknikoa izan zen adierazten du (argindarik gabe, internetik gabe, sistemaren hutsegitea). Lehenetsita "N".

--- a/langs/gl_ES/verifactu.lang
+++ b/langs/gl_ES/verifactu.lang
@@ -571,4 +571,40 @@ VERIFACTU_SCHEMAS_NOT_DOWNLOADED = No descargados
 VERIFACTU_SCHEMAS_LAST_DOWNLOAD = Última descarga
 VERIFACTU_SCHEMAS_DOWNLOAD_BUTTON = Descargar/Actualizar esquemas
 VERIFACTU_SCHEMAS_DOWNLOAD_SUCCESS = Esquemas descargados correctamente (%s archivos)
-VERIFACTU_SCHEMAS_DOWNLOAD_ERROR = Error al descargar esquemas: %s
+VERIFACTU_SCHEMAS_DOWNLOAD_ERROR = Erro ao descargar esquemas: %s
+
+# Legacy key aliases (old Spanish extrafield labels stored in DB from original installations)
+verifactu_INICIO_Separador1 = <span class="badge badge-status1 badge-status">Datos VeriFactu</span><span class="classfortooltip" style="padding: 0px; padding-right: 3px !important;" title="Estado da factura en VeriFactu"><span class="fas fa-info-circle em088 opacityhigh" style="vertical-align: middle; cursor: help"></span></span>
+verifactu_INICIO_Separador2 = <span class="badge badge-status1 badge-status">CAMPOS FISCAIS ⚠️</span><span class="classfortooltip" style="padding: 0px; padding-right: 3px !important;" title="⚠️ IMPORTANTE: Imposto, Chave Réxime, Cualificación e Operación Exenta son responsabilidade da empresa. Consulte co seu asesor fiscal en caso de dúbida."><span class="fas fa-info-circle em088 opacityhigh" style="vertical-align: middle; cursor: help"></span></span>
+verifactu_ESTADO = Estado
+verifactu_ESTADOTooltip = Estado da factura en VeriFactu
+verifactu_CSV_Factura = Código CSV
+verifactu_CSV_FacturaTooltip = Código de verificación da AEAT. Se non existe, a factura non foi enviada.
+verifactu_ID_Factura = ID en VeriFactu
+verifactu_ID_FacturaTooltip = Identificador da factura en VeriFactu
+verifactu_FECHA_Factura = Data de emisión
+verifactu_FECHA_FacturaTooltip = Data de emisión rexistrada en VeriFactu
+verifactu_ULTIMA_salida = Última resposta
+verifactu_ULTIMA_salidaTooltip = Última resposta de VeriFactu
+verifactu_ULTIMAFECHA_Modificacion = Última modificación
+verifactu_ULTIMAFECHA_ModificacionTooltip = Data de última modificación en VeriFactu
+verifactu_HUELLA = Pegada dixital
+verifactu_HUELLATooltip = Pegada SHA-256 da factura
+verifactu_FECHA_HORA_Generacion = Data/hora de pegada
+verifactu_FECHA_HORA_GeneracionTooltip = Data e hora de xeración da pegada (ISO 8601)
+VERIFACTU_entorno = Contorno (probas/produción)
+VERIFACTU_entornoTooltip = Contorno no que se enviou a factura a VeriFactu
+VERIFACTU_modo = Modo de operación
+VERIFACTU_modoTooltip = Modo de operación VeriFactu
+verifactu_Factura_Tipo = Tipo de factura
+verifactu_Factura_TipoTooltip = Tipo de factura para VeriFactu
+verifactu_IMPUESTO = Imposto
+verifactu_IMPUESTOTooltip = Tipo de imposto aplicable. Por defecto IVE. Necesario para a tipoloxía de factura.
+verifactu_CLAVE_Regimen = Chave Réxime
+verifactu_CLAVE_RegimenTooltip = Chave do réxime especial. Só aplicable para IVE ou IGIC, non para IPSI ou OUTROS.
+verifactu_CALIFICACION_Operacion = Cualificación Operación
+verifactu_CALIFICACION_OperacionTooltip = Chave de operación suxeita/non exenta ou non suxeita. S1=Sen inversión, S2=Con inversión, N1=Non suxeita art.7,14, N2=Non suxeita localización.
+verifactu_OPERACION_Exenta = Operación Exenta
+verifactu_OPERACION_ExentaTooltip = Tipo de exención (E1-E6) cando a operación está exenta de IVE/IGIC/IPSI.
+verifactu_INCIDENCIA = Incidencia
+verifactu_INCIDENCIATooltip = Indica se houbo incidencia técnica (sen electricidade, sen internet, fallo do sistema). Por defecto "N".


### PR DESCRIPTION
Old installations have the original Spanish label keys stored in the DB (e.g. verifactu_ESTADO, verifactu_CSV_Factura, VERIFACTU_entorno) because addExtraField() doesn't update existing fields. The lang files only had the new English keys (verifactu_STATUS, verifactu_INVOICE_CSV, etc.), causing raw key names to display instead of translated labels.

Added backward-compatible aliases mapping old Spanish keys to proper translations in all 5 languages: es_ES, en_US, ca_ES, eu_ES, gl_ES.

https://claude.ai/code/session_01Ku11JstopJ3S1Fdmjorip8