### PR TITLE
FIX enforce VeriFactu isolation across MultiCompany entities

### DIFF
--- a/admin/setup.php
+++ b/admin/setup.php
@@ -410,6 +410,18 @@ if ($action == 'update' && !empty($user->admin)) {
 		$action = '';
 		$error++;
 	}
+
+	// Once the first fiscal fingerprint exists, the taxpayer identity that owns
+	// the chain is immutable. Certificate rotation remains possible and audited
+	// through its entity-specific fingerprint.
+	$currentTaxId = $conf->global->VERIFACTU_HOLDER_NIF ?? '';
+	if ($action == 'update'
+		&& normalizeVerifactuTaxIdentifier($postedTaxId) !== normalizeVerifactuTaxIdentifier($currentTaxId)
+		&& hasVerifactuFiscalRecords((int) $conf->entity)) {
+		setEventMessages($langs->trans('VERIFACTU_TAX_IDENTITY_LOCKED'), null, 'errors');
+		$action = '';
+		$error++;
+	}
 }
 
 // For retrocompatibility Dolibarr < 15.0

--- a/admin/setup.php
+++ b/admin/setup.php
@@ -400,6 +400,18 @@ $dirmodels = array_merge(array('/'), (array) $conf->modules_parts['models']);
  * Actions
  */
 
+// Reject a duplicated taxpayer identity before FormSetup persists any value.
+// This is the earliest safeguard and complements activation/runtime checks.
+if ($action == 'update' && !empty($user->admin)) {
+	$postedTaxId = GETPOST('VERIFACTU_HOLDER_NIF', 'alphanohtml');
+	$conflictEntity = null;
+	if (!isVerifactuTaxIdentityUnique($postedTaxId, (int) $conf->entity, $conflictEntity)) {
+		setEventMessages($langs->trans('VERIFACTU_TAX_IDENTITY_ALREADY_USED', $conflictEntity), null, 'errors');
+		$action = '';
+		$error++;
+	}
+}
+
 // For retrocompatibility Dolibarr < 15.0
 if (versioncompare(explode('.', DOL_VERSION), array(15)) < 0 && $action == 'update' && !empty($user->admin)) {
 	$formSetup->saveConfFromPost();

--- a/admin/setup.php
+++ b/admin/setup.php
@@ -410,18 +410,6 @@ if ($action == 'update' && !empty($user->admin)) {
 		$action = '';
 		$error++;
 	}
-
-	// Once the first fiscal fingerprint exists, the taxpayer identity that owns
-	// the chain is immutable. Certificate rotation remains possible and audited
-	// through its entity-specific fingerprint.
-	$currentTaxId = $conf->global->VERIFACTU_HOLDER_NIF ?? '';
-	if ($action == 'update'
-		&& normalizeVerifactuTaxIdentifier($postedTaxId) !== normalizeVerifactuTaxIdentifier($currentTaxId)
-		&& hasVerifactuFiscalRecords((int) $conf->entity)) {
-		setEventMessages($langs->trans('VERIFACTU_TAX_IDENTITY_LOCKED'), null, 'errors');
-		$action = '';
-		$error++;
-	}
 }
 
 // For retrocompatibility Dolibarr < 15.0

--- a/class/verifactu.utils.php
+++ b/class/verifactu.utils.php
@@ -146,7 +146,8 @@ class VerifactuUtils
 		$sql = "SELECT f.rowid, f.ref, f.datef, f.entity";
 		$sql .= " FROM " . MAIN_DB_PREFIX . "facture f";
 		$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "facture_extrafields fe ON f.rowid = fe.fk_object";
-		$sql .= " WHERE f.entity = " . getEntity('invoice');
+		// Retry with the current entity configuration and certificate only.
+		$sql .= " WHERE f.entity = " . ((int) $conf->entity);
 		$sql .= " AND f.fk_statut > 0"; // Only validated invoices
 		$sql .= " AND f.ref NOT LIKE '%PROV%'"; // Exclude provisional invoices
 		$sql .= " AND (fe.verifactu_error LIKE '%NO_INTERNET_CONNECTION%' OR fe.verifactu_error LIKE '%SERVICE_UNAVAILABLE%')"; // With connection error

--- a/core/modules/modVerifactu.class.php
+++ b/core/modules/modVerifactu.class.php
@@ -559,11 +559,10 @@ class modVerifactu extends DolibarrModules
 
 		// VeriFactu fiscal resources must remain isolated for the current legal entity.
 		dol_include_once('/verifactu/lib/functions/functions.configuration.php');
-		foreach (array('invoice', 'invoicenumber', 'bankaccount') as $element) {
-			if (!isEntitySharingAllowed($element, (int) $conf->entity)) {
-				$this->error = $langs->trans('VERIFACTU_ENTITY_SHARING_NOT_ALLOWED', $element);
-				return -1;
-			}
+		$sharedElement = null;
+		if (!isVerifactuEntityIsolated((int) $conf->entity, $sharedElement)) {
+			$this->error = $langs->trans('VERIFACTU_ENTITY_SHARING_NOT_ALLOWED', $sharedElement);
+			return -1;
 		}
 
 		// Include VeriFactu data types

--- a/core/modules/modVerifactu.class.php
+++ b/core/modules/modVerifactu.class.php
@@ -565,6 +565,15 @@ class modVerifactu extends DolibarrModules
 			return -1;
 		}
 
+		// The NIF is the primary identity of the taxpayer. Never allow a second
+		// VeriFactu entity to activate with an identity already in use.
+		$conflictEntity = null;
+		$taxId = $conf->global->VERIFACTU_HOLDER_NIF ?? '';
+		if (!isVerifactuTaxIdentityUnique($taxId, (int) $conf->entity, $conflictEntity)) {
+			$this->error = $langs->trans('VERIFACTU_TAX_IDENTITY_ALREADY_USED', $conflictEntity);
+			return -1;
+		}
+
 		// Include VeriFactu data types
 		require_once(dol_buildpath('/verifactu/lib/verifactu-types.array.php', 0));
 

--- a/core/modules/modVerifactu.class.php
+++ b/core/modules/modVerifactu.class.php
@@ -557,6 +557,15 @@ class modVerifactu extends DolibarrModules
 			return -1;
 		}
 
+		// VeriFactu fiscal resources must remain isolated for the current legal entity.
+		dol_include_once('/verifactu/lib/functions/functions.configuration.php');
+		foreach (array('invoice', 'invoicenumber', 'bankaccount') as $element) {
+			if (!isEntitySharingAllowed($element, (int) $conf->entity)) {
+				$this->error = $langs->trans('VERIFACTU_ENTITY_SHARING_NOT_ALLOWED', $element);
+				return -1;
+			}
+		}
+
 		// Include VeriFactu data types
 		require_once(dol_buildpath('/verifactu/lib/verifactu-types.array.php', 0));
 

--- a/core/modules/modVerifactu.class.php
+++ b/core/modules/modVerifactu.class.php
@@ -1174,7 +1174,7 @@ class modVerifactu extends DolibarrModules
 
 			//Default values
 			$dFalues = [
-				['type' => 'mandatory', 'entity' => 1, 'page' => 'societe/card.php', 'param' => 'country_id', 'value' => '']
+				['type' => 'mandatory', 'entity' => $conf->entity, 'page' => 'societe/card.php', 'param' => 'country_id', 'value' => '']
 
 			];
 
@@ -1194,7 +1194,9 @@ class modVerifactu extends DolibarrModules
 		// Permissions
 		$this->remove($options);
 		$badge = '<div class="center"><span class="badge badge-status8 classfortooltip badge-status" attr-status="' . $langs->trans('VERIFACTU_STATUS_NOT_SEND') . '">' . $langs->trans('VERIFACTU_STATUS_NOT_SEND') . '</span></div>';
-		$sql1 = "UPDATE " . MAIN_DB_PREFIX . "facture_extrafields SET verifactu_estado='$badge' WHERE verifactu_estado IS NULL";
+		$sql1 = "UPDATE " . MAIN_DB_PREFIX . "facture_extrafields SET verifactu_estado='$badge'";
+		$sql1 .= " WHERE verifactu_estado IS NULL AND fk_object IN (";
+		$sql1 .= "SELECT rowid FROM " . MAIN_DB_PREFIX . "facture WHERE entity = " . ((int) $conf->entity) . ")";
 
 		$sql = array($sql1);
 		dol_include_once('/verifactu/lib/verifactu.lib.php');

--- a/core/triggers/interface_999_modVerifactu_VerifactuTriggers.class.php
+++ b/core/triggers/interface_999_modVerifactu_VerifactuTriggers.class.php
@@ -238,6 +238,14 @@ class InterfaceVerifactuTriggers extends DolibarrTriggers
 			return -1;
 		}
 
+		// A MultiCompany entity enabled for VeriFactu must represent a distinct taxpayer.
+		$conflictEntity = null;
+		$taxId = $conf->global->VERIFACTU_HOLDER_NIF ?? '';
+		if (!isVerifactuTaxIdentityUnique($taxId, (int) $object->entity, $conflictEntity)) {
+			$this->errors[] = $langs->trans('VERIFACTU_TAX_IDENTITY_ALREADY_USED', $conflictEntity);
+			return -1;
+		}
+
 		// Include utilities class to process pending invoices
 		dol_include_once('/verifactu/class/verifactu.utils.php');
 

--- a/core/triggers/interface_999_modVerifactu_VerifactuTriggers.class.php
+++ b/core/triggers/interface_999_modVerifactu_VerifactuTriggers.class.php
@@ -446,7 +446,7 @@ class InterfaceVerifactuTriggers extends DolibarrTriggers
 		$sql = "SELECT COUNT(*) as count FROM " . MAIN_DB_PREFIX . "facture f ";
 		$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "facture_extrafields fe ON f.rowid = fe.fk_object ";
 		$sql .= "WHERE fk_soc = " . $object->id . " AND fe.verifactu_csv_factura IS NOT NULL AND fe.verifactu_huella IS NOT NULL";
-		$sql .= "  AND f.entity IN (" . getEntity('invoice') . ")";
+		$sql .= "  AND f.entity = " . ((int) $conf->entity);
 
 		$resql = $this->db->query($sql);
 		if ($resql) {

--- a/core/triggers/interface_999_modVerifactu_VerifactuTriggers.class.php
+++ b/core/triggers/interface_999_modVerifactu_VerifactuTriggers.class.php
@@ -222,6 +222,22 @@ class InterfaceVerifactuTriggers extends DolibarrTriggers
 	}
 	public function billValidate($action, $object, User $user, Translate $langs, Conf $conf)
 	{
+		dol_include_once('/verifactu/lib/functions/functions.configuration.php');
+		$langs->load('verifactu@verifactu');
+
+		// Never let the active entity validate an invoice owned by another legal entity.
+		if ((int) $object->entity !== (int) $conf->entity) {
+			$this->errors[] = $langs->trans('VERIFACTU_FOREIGN_ENTITY_INVOICE_NOT_ALLOWED');
+			return -1;
+		}
+
+		// Recheck at validation time in case MultiCompany sharing changed after activation.
+		$sharedElement = null;
+		if (!isVerifactuEntityIsolated((int) $object->entity, $sharedElement)) {
+			$this->errors[] = $langs->trans('VERIFACTU_ENTITY_SHARING_NOT_ALLOWED', $sharedElement);
+			return -1;
+		}
+
 		// Include utilities class to process pending invoices
 		dol_include_once('/verifactu/class/verifactu.utils.php');
 

--- a/integrity.php
+++ b/integrity.php
@@ -90,7 +90,7 @@ try {
 		// Check if invoices have already been sent to VeriFactu
 		$sql = "SELECT COUNT(*) as count FROM " . MAIN_DB_PREFIX . "facture f";
 		$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "facture_extrafields fe ON f.rowid = fe.fk_object";
-		$sql .= " WHERE 1=1 ";
+		$sql .= " WHERE f.entity = " . ((int) $conf->entity);
 		$sql .= " AND fe.verifactu_csv_factura IS NOT NULL AND fe.verifactu_csv_factura != ''";
 		$sql .= " AND fe.verifactu_estado IS NOT NULL AND fe.verifactu_estado != ''";
 		$sql .= " LIMIT 1";
@@ -106,7 +106,8 @@ try {
 		// Count invoices with VeriFactu errors
 		$sqlErrors = "SELECT COUNT(*) as count FROM " . MAIN_DB_PREFIX . "facture f";
 		$sqlErrors .= " INNER JOIN " . MAIN_DB_PREFIX . "facture_extrafields fe ON f.rowid = fe.fk_object";
-		$sqlErrors .= " WHERE fe.verifactu_error IS NOT NULL AND fe.verifactu_error != ''";
+		$sqlErrors .= " WHERE f.entity = " . ((int) $conf->entity);
+		$sqlErrors .= " AND fe.verifactu_error IS NOT NULL AND fe.verifactu_error != ''";
 		$sqlErrors .= " AND f.fk_statut > 0";
 		$sqlErrors .= " LIMIT 1";
 

--- a/langs/en_US/verifactu.lang
+++ b/langs/en_US/verifactu.lang
@@ -721,3 +721,4 @@ verifactu_INCIDENCIATooltip = Indicates technical incident (no electricity, no i
 VERIFACTU_ENTITY_SHARING_NOT_ALLOWED=VeriFactu requires the MultiCompany resource "%s" to remain entity-specific, but it is shared from or with this entity. Disable sharing before continuing.
 VERIFACTU_FOREIGN_ENTITY_INVOICE_NOT_ALLOWED=VeriFactu cannot validate an invoice that belongs to another entity.
 VERIFACTU_TAX_IDENTITY_ALREADY_USED=The configured taxpayer identity is already used by VeriFactu entity %s. Each entity must represent a different taxpayer.
+VERIFACTU_TAX_IDENTITY_LOCKED=The taxpayer NIF cannot be changed because this entity already contains chained VeriFactu fiscal records.

--- a/langs/en_US/verifactu.lang
+++ b/langs/en_US/verifactu.lang
@@ -721,4 +721,3 @@ verifactu_INCIDENCIATooltip = Indicates technical incident (no electricity, no i
 VERIFACTU_ENTITY_SHARING_NOT_ALLOWED=VeriFactu requires the MultiCompany resource "%s" to remain entity-specific, but it is shared from or with this entity. Disable sharing before continuing.
 VERIFACTU_FOREIGN_ENTITY_INVOICE_NOT_ALLOWED=VeriFactu cannot validate an invoice that belongs to another entity.
 VERIFACTU_TAX_IDENTITY_ALREADY_USED=The configured taxpayer identity is already used by VeriFactu entity %s. Each entity must represent a different taxpayer.
-VERIFACTU_TAX_IDENTITY_LOCKED=The taxpayer NIF cannot be changed because this entity already contains chained VeriFactu fiscal records.

--- a/langs/en_US/verifactu.lang
+++ b/langs/en_US/verifactu.lang
@@ -720,3 +720,4 @@ verifactu_INCIDENCIA = Incident
 verifactu_INCIDENCIATooltip = Indicates technical incident (no electricity, no internet, system failure). Defaults to "N".
 VERIFACTU_ENTITY_SHARING_NOT_ALLOWED=VeriFactu requires the MultiCompany resource "%s" to remain entity-specific, but it is shared from or with this entity. Disable sharing before continuing.
 VERIFACTU_FOREIGN_ENTITY_INVOICE_NOT_ALLOWED=VeriFactu cannot validate an invoice that belongs to another entity.
+VERIFACTU_TAX_IDENTITY_ALREADY_USED=The configured taxpayer identity is already used by VeriFactu entity %s. Each entity must represent a different taxpayer.

--- a/langs/en_US/verifactu.lang
+++ b/langs/en_US/verifactu.lang
@@ -718,3 +718,4 @@ verifactu_OPERACION_Exenta = Exempt Operation
 verifactu_OPERACION_ExentaTooltip = Exemption type (E1-E6) when operation is VAT/IGIC/IPSI exempt.
 verifactu_INCIDENCIA = Incident
 verifactu_INCIDENCIATooltip = Indicates technical incident (no electricity, no internet, system failure). Defaults to "N".
+VERIFACTU_ENTITY_SHARING_NOT_ALLOWED=VeriFactu cannot be enabled because the MultiCompany resource "%s" is shared from or with this entity. Disable sharing before continuing.

--- a/langs/en_US/verifactu.lang
+++ b/langs/en_US/verifactu.lang
@@ -718,4 +718,5 @@ verifactu_OPERACION_Exenta = Exempt Operation
 verifactu_OPERACION_ExentaTooltip = Exemption type (E1-E6) when operation is VAT/IGIC/IPSI exempt.
 verifactu_INCIDENCIA = Incident
 verifactu_INCIDENCIATooltip = Indicates technical incident (no electricity, no internet, system failure). Defaults to "N".
-VERIFACTU_ENTITY_SHARING_NOT_ALLOWED=VeriFactu cannot be enabled because the MultiCompany resource "%s" is shared from or with this entity. Disable sharing before continuing.
+VERIFACTU_ENTITY_SHARING_NOT_ALLOWED=VeriFactu requires the MultiCompany resource "%s" to remain entity-specific, but it is shared from or with this entity. Disable sharing before continuing.
+VERIFACTU_FOREIGN_ENTITY_INVOICE_NOT_ALLOWED=VeriFactu cannot validate an invoice that belongs to another entity.

--- a/langs/es_ES/verifactu.lang
+++ b/langs/es_ES/verifactu.lang
@@ -721,4 +721,3 @@ verifactu_INCIDENCIATooltip = Indica si hubo incidencia técnica (sin electricid
 VERIFACTU_ENTITY_SHARING_NOT_ALLOWED=Verifactu requiere que el recurso Multicompany "%s" sea independiente, pero está compartido por esta entidad o con esta entidad. Desactive la compartición antes de continuar.
 VERIFACTU_FOREIGN_ENTITY_INVOICE_NOT_ALLOWED=Verifactu no puede validar una factura que pertenece a otra entidad.
 VERIFACTU_TAX_IDENTITY_ALREADY_USED=La identidad fiscal configurada ya está siendo utilizada por la entidad Verifactu %s. Cada entidad debe representar un obligado tributario diferente.
-VERIFACTU_TAX_IDENTITY_LOCKED=No se puede modificar el NIF del obligado tributario porque esta entidad ya contiene registros fiscales encadenados de Verifactu.

--- a/langs/es_ES/verifactu.lang
+++ b/langs/es_ES/verifactu.lang
@@ -721,3 +721,4 @@ verifactu_INCIDENCIATooltip = Indica si hubo incidencia técnica (sin electricid
 VERIFACTU_ENTITY_SHARING_NOT_ALLOWED=Verifactu requiere que el recurso Multicompany "%s" sea independiente, pero está compartido por esta entidad o con esta entidad. Desactive la compartición antes de continuar.
 VERIFACTU_FOREIGN_ENTITY_INVOICE_NOT_ALLOWED=Verifactu no puede validar una factura que pertenece a otra entidad.
 VERIFACTU_TAX_IDENTITY_ALREADY_USED=La identidad fiscal configurada ya está siendo utilizada por la entidad Verifactu %s. Cada entidad debe representar un obligado tributario diferente.
+VERIFACTU_TAX_IDENTITY_LOCKED=No se puede modificar el NIF del obligado tributario porque esta entidad ya contiene registros fiscales encadenados de Verifactu.

--- a/langs/es_ES/verifactu.lang
+++ b/langs/es_ES/verifactu.lang
@@ -718,4 +718,5 @@ verifactu_OPERACION_Exenta = Operación Exenta
 verifactu_OPERACION_ExentaTooltip = Tipo de exención (E1-E6) cuando la operación está exenta de IVA/IGIC/IPSI.
 verifactu_INCIDENCIA = Incidencia
 verifactu_INCIDENCIATooltip = Indica si hubo incidencia técnica (sin electricidad, sin internet, fallo del sistema). Por defecto "N".
-VERIFACTU_ENTITY_SHARING_NOT_ALLOWED=No se puede activar Verifactu porque el recurso Multicompany "%s" está compartido por esta entidad o con esta entidad. Desactive la compartición antes de continuar.
+VERIFACTU_ENTITY_SHARING_NOT_ALLOWED=Verifactu requiere que el recurso Multicompany "%s" sea independiente, pero está compartido por esta entidad o con esta entidad. Desactive la compartición antes de continuar.
+VERIFACTU_FOREIGN_ENTITY_INVOICE_NOT_ALLOWED=Verifactu no puede validar una factura que pertenece a otra entidad.

--- a/langs/es_ES/verifactu.lang
+++ b/langs/es_ES/verifactu.lang
@@ -720,3 +720,4 @@ verifactu_INCIDENCIA = Incidencia
 verifactu_INCIDENCIATooltip = Indica si hubo incidencia técnica (sin electricidad, sin internet, fallo del sistema). Por defecto "N".
 VERIFACTU_ENTITY_SHARING_NOT_ALLOWED=Verifactu requiere que el recurso Multicompany "%s" sea independiente, pero está compartido por esta entidad o con esta entidad. Desactive la compartición antes de continuar.
 VERIFACTU_FOREIGN_ENTITY_INVOICE_NOT_ALLOWED=Verifactu no puede validar una factura que pertenece a otra entidad.
+VERIFACTU_TAX_IDENTITY_ALREADY_USED=La identidad fiscal configurada ya está siendo utilizada por la entidad Verifactu %s. Cada entidad debe representar un obligado tributario diferente.

--- a/langs/es_ES/verifactu.lang
+++ b/langs/es_ES/verifactu.lang
@@ -718,3 +718,4 @@ verifactu_OPERACION_Exenta = Operación Exenta
 verifactu_OPERACION_ExentaTooltip = Tipo de exención (E1-E6) cuando la operación está exenta de IVA/IGIC/IPSI.
 verifactu_INCIDENCIA = Incidencia
 verifactu_INCIDENCIATooltip = Indica si hubo incidencia técnica (sin electricidad, sin internet, fallo del sistema). Por defecto "N".
+VERIFACTU_ENTITY_SHARING_NOT_ALLOWED=No se puede activar Verifactu porque el recurso Multicompany "%s" está compartido por esta entidad o con esta entidad. Desactive la compartición antes de continuar.

--- a/lib/functions/functions.certificates.php
+++ b/lib/functions/functions.certificates.php
@@ -536,6 +536,27 @@ function getCertificateOptions()
 		return false;
 	}
 
+	// A certificate identifies the taxpayer and must not be reused by another
+	// VeriFactu-enabled MultiCompany entity.
+	$certificateContent = @file_get_contents($certPath);
+	$certificate = ($certificateContent !== false ? @openssl_x509_read($certificateContent) : false);
+	$fingerprint = ($certificate ? @openssl_x509_fingerprint($certificate, 'sha256') : false);
+	if (empty($fingerprint)) {
+		$GLOBALS['verifactu_cert_error'] = 'Unable to calculate the X.509 certificate fingerprint';
+		return false;
+	}
+
+	$conflictEntity = null;
+	if (!isVerifactuCertificateFingerprintUnique($fingerprint, (int) $conf->entity, $conflictEntity)) {
+		$GLOBALS['verifactu_cert_error'] = 'Certificate already used by VeriFactu entity ' . (int) $conflictEntity;
+		return false;
+	}
+	$result = dolibarr_set_const($db, 'VERIFACTU_CERTIFICATE_FINGERPRINT_SHA256', strtolower($fingerprint), 'chaine', 0, '', $conf->entity);
+	if ($result < 0) {
+		$GLOBALS['verifactu_cert_error'] = 'Unable to register the entity certificate fingerprint';
+		return false;
+	}
+
 	dol_syslog("VERIFACTU: Certificate options prepared successfully", LOG_DEBUG);
 	return $certOptions;
 }

--- a/lib/functions/functions.certificates.php
+++ b/lib/functions/functions.certificates.php
@@ -54,33 +54,37 @@ function prepareLocalCertificate(
 	}
 
 	$isWindows = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
-	$opensslBin = $isWindows ? "\"$winOpensslPath\"" : 'openssl';
+	$opensslBin = $isWindows ? escapeshellarg($winOpensslPath) : 'openssl';
 
 	$certOut = $outputPath . '_cert.pem';
 	$keyOut = $outputPath . '_key.pem';
 
 	// Extract certificate without key
-	$cmdCert = "$opensslBin pkcs12 -in \"$certificateFile\" -clcerts -nokeys -out \"$certOut\" -password pass:$certificatePassword";
+	$cmdCert = $opensslBin . ' pkcs12 -in ' . escapeshellarg($certificateFile)
+		. ' -clcerts -nokeys -out ' . escapeshellarg($certOut)
+		. ' -password ' . escapeshellarg('pass:' . $certificatePassword);
 	exec($cmdCert, $outputCert, $codeCert);
 
 	if ($codeCert !== 0 || !file_exists($certOut)) {
-		die("Error extracting certificate.");
+		throw new RuntimeException("Error extracting certificate.");
 	}
 
 	// Extract private key (with or without passphrase)
 	$passOut = $privateKeyPassword ?? $certificatePassword;
-	$cmdKey = "$opensslBin pkcs12 -in \"$certificateFile\" -nocerts " .
-		($encryptKey ? '' : '-nodes') .
-		" -out \"$keyOut\" -password pass:$certificatePassword" .
-		($encryptKey ? " -passout pass:$passOut" : '');
+	$cmdKey = $opensslBin . ' pkcs12 -in ' . escapeshellarg($certificateFile)
+		. ' -nocerts ' . ($encryptKey ? '' : '-nodes ')
+		. '-out ' . escapeshellarg($keyOut)
+		. ' -password ' . escapeshellarg('pass:' . $certificatePassword)
+		. ($encryptKey ? ' -passout ' . escapeshellarg('pass:' . $passOut) : '');
 	exec($cmdKey, $outputKey, $codeKey);
 
 	if ($codeKey !== 0 || !file_exists($keyOut)) {
-		die("Error extracting private key.");
+		throw new RuntimeException("Error extracting private key.");
 	}
 
 	// Combine into a single .pem
 	file_put_contents($bundleFile, file_get_contents($certOut) . "\n" . file_get_contents($keyOut));
+	@chmod($bundleFile, 0600);
 
 	// Delete temporary files
 	unlink($certOut);
@@ -153,7 +157,7 @@ function extractPrivateKeyWithOpenSSL(
 ): array {
 
 	$isWindows = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
-	$opensslBin = $isWindows ? "\"$winOpensslPath\"" : 'openssl';
+	$opensslBin = $isWindows ? escapeshellarg($winOpensslPath) : 'openssl';
 
 	// Verify binary exists
 	if ($isWindows && !file_exists($winOpensslPath)) {
@@ -168,7 +172,9 @@ function extractPrivateKeyWithOpenSSL(
 
 	try {
 		// Command to extract private key without encryption
-		$cmd = "$opensslBin pkcs12 -in \"$certificateFile\" -nocerts -nodes -out \"$tempKey\" -password pass:$certificatePassword 2>&1";
+		$cmd = $opensslBin . ' pkcs12 -in ' . escapeshellarg($certificateFile)
+			. ' -nocerts -nodes -out ' . escapeshellarg($tempKey)
+			. ' -password ' . escapeshellarg('pass:' . $certificatePassword) . ' 2>&1';
 
 		// Execute command
 		exec($cmd, $output, $returnCode);
@@ -252,7 +258,7 @@ function extractPublicCertificateWithOpenSSL(
 ): array {
 
 	$isWindows = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
-	$opensslBin = $isWindows ? "\"$winOpensslPath\"" : 'openssl';
+	$opensslBin = $isWindows ? escapeshellarg($winOpensslPath) : 'openssl';
 
 	if ($isWindows && !file_exists($winOpensslPath)) {
 		return [
@@ -264,7 +270,9 @@ function extractPublicCertificateWithOpenSSL(
 	$tempCert = tempnam(sys_get_temp_dir(), 'verifactu_cert_') . '.pem';
 
 	try {
-		$cmd = "$opensslBin pkcs12 -in \"$certificateFile\" -clcerts -nokeys -out \"$tempCert\" -password pass:$certificatePassword 2>&1";
+		$cmd = $opensslBin . ' pkcs12 -in ' . escapeshellarg($certificateFile)
+			. ' -clcerts -nokeys -out ' . escapeshellarg($tempCert)
+			. ' -password ' . escapeshellarg('pass:' . $certificatePassword) . ' 2>&1';
 
 		exec($cmd, $output, $returnCode);
 
@@ -683,6 +691,19 @@ function validateCertificateAndKey($certPath, $certPassphrase = '')
 	if ($cert === false) {
 		dol_syslog("VERIFACTU: Error reading X.509 certificate", LOG_ERR);
 		$GLOBALS['verifactu_cert_error'] = "Error reading X.509 certificate - invalid format";
+		return false;
+	}
+
+	// Reject certificates that are not currently valid. A matching private key
+	// is not sufficient when the X.509 validity window has expired or has not begun.
+	$certInfo = openssl_x509_parse($cert);
+	$now = time();
+	$validFrom = isset($certInfo['validFrom_time_t']) ? (int) $certInfo['validFrom_time_t'] : 0;
+	$validTo = isset($certInfo['validTo_time_t']) ? (int) $certInfo['validTo_time_t'] : 0;
+	if (($validFrom > 0 && $now < $validFrom) || ($validTo > 0 && $now > $validTo)) {
+		openssl_x509_free($cert);
+		dol_syslog("VERIFACTU: Certificate is outside its X.509 validity period", LOG_ERR);
+		$GLOBALS['verifactu_cert_error'] = "Certificate is outside its X.509 validity period";
 		return false;
 	}
 

--- a/lib/functions/functions.certificates.php
+++ b/lib/functions/functions.certificates.php
@@ -54,37 +54,33 @@ function prepareLocalCertificate(
 	}
 
 	$isWindows = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
-	$opensslBin = $isWindows ? escapeshellarg($winOpensslPath) : 'openssl';
+	$opensslBin = $isWindows ? "\"$winOpensslPath\"" : 'openssl';
 
 	$certOut = $outputPath . '_cert.pem';
 	$keyOut = $outputPath . '_key.pem';
 
 	// Extract certificate without key
-	$cmdCert = $opensslBin . ' pkcs12 -in ' . escapeshellarg($certificateFile)
-		. ' -clcerts -nokeys -out ' . escapeshellarg($certOut)
-		. ' -password ' . escapeshellarg('pass:' . $certificatePassword);
+	$cmdCert = "$opensslBin pkcs12 -in \"$certificateFile\" -clcerts -nokeys -out \"$certOut\" -password pass:$certificatePassword";
 	exec($cmdCert, $outputCert, $codeCert);
 
 	if ($codeCert !== 0 || !file_exists($certOut)) {
-		throw new RuntimeException("Error extracting certificate.");
+		die("Error extracting certificate.");
 	}
 
 	// Extract private key (with or without passphrase)
 	$passOut = $privateKeyPassword ?? $certificatePassword;
-	$cmdKey = $opensslBin . ' pkcs12 -in ' . escapeshellarg($certificateFile)
-		. ' -nocerts ' . ($encryptKey ? '' : '-nodes ')
-		. '-out ' . escapeshellarg($keyOut)
-		. ' -password ' . escapeshellarg('pass:' . $certificatePassword)
-		. ($encryptKey ? ' -passout ' . escapeshellarg('pass:' . $passOut) : '');
+	$cmdKey = "$opensslBin pkcs12 -in \"$certificateFile\" -nocerts " .
+		($encryptKey ? '' : '-nodes') .
+		" -out \"$keyOut\" -password pass:$certificatePassword" .
+		($encryptKey ? " -passout pass:$passOut" : '');
 	exec($cmdKey, $outputKey, $codeKey);
 
 	if ($codeKey !== 0 || !file_exists($keyOut)) {
-		throw new RuntimeException("Error extracting private key.");
+		die("Error extracting private key.");
 	}
 
 	// Combine into a single .pem
 	file_put_contents($bundleFile, file_get_contents($certOut) . "\n" . file_get_contents($keyOut));
-	@chmod($bundleFile, 0600);
 
 	// Delete temporary files
 	unlink($certOut);
@@ -157,7 +153,7 @@ function extractPrivateKeyWithOpenSSL(
 ): array {
 
 	$isWindows = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
-	$opensslBin = $isWindows ? escapeshellarg($winOpensslPath) : 'openssl';
+	$opensslBin = $isWindows ? "\"$winOpensslPath\"" : 'openssl';
 
 	// Verify binary exists
 	if ($isWindows && !file_exists($winOpensslPath)) {
@@ -172,9 +168,7 @@ function extractPrivateKeyWithOpenSSL(
 
 	try {
 		// Command to extract private key without encryption
-		$cmd = $opensslBin . ' pkcs12 -in ' . escapeshellarg($certificateFile)
-			. ' -nocerts -nodes -out ' . escapeshellarg($tempKey)
-			. ' -password ' . escapeshellarg('pass:' . $certificatePassword) . ' 2>&1';
+		$cmd = "$opensslBin pkcs12 -in \"$certificateFile\" -nocerts -nodes -out \"$tempKey\" -password pass:$certificatePassword 2>&1";
 
 		// Execute command
 		exec($cmd, $output, $returnCode);
@@ -258,7 +252,7 @@ function extractPublicCertificateWithOpenSSL(
 ): array {
 
 	$isWindows = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
-	$opensslBin = $isWindows ? escapeshellarg($winOpensslPath) : 'openssl';
+	$opensslBin = $isWindows ? "\"$winOpensslPath\"" : 'openssl';
 
 	if ($isWindows && !file_exists($winOpensslPath)) {
 		return [
@@ -270,9 +264,7 @@ function extractPublicCertificateWithOpenSSL(
 	$tempCert = tempnam(sys_get_temp_dir(), 'verifactu_cert_') . '.pem';
 
 	try {
-		$cmd = $opensslBin . ' pkcs12 -in ' . escapeshellarg($certificateFile)
-			. ' -clcerts -nokeys -out ' . escapeshellarg($tempCert)
-			. ' -password ' . escapeshellarg('pass:' . $certificatePassword) . ' 2>&1';
+		$cmd = "$opensslBin pkcs12 -in \"$certificateFile\" -clcerts -nokeys -out \"$tempCert\" -password pass:$certificatePassword 2>&1";
 
 		exec($cmd, $output, $returnCode);
 
@@ -691,19 +683,6 @@ function validateCertificateAndKey($certPath, $certPassphrase = '')
 	if ($cert === false) {
 		dol_syslog("VERIFACTU: Error reading X.509 certificate", LOG_ERR);
 		$GLOBALS['verifactu_cert_error'] = "Error reading X.509 certificate - invalid format";
-		return false;
-	}
-
-	// Reject certificates that are not currently valid. A matching private key
-	// is not sufficient when the X.509 validity window has expired or has not begun.
-	$certInfo = openssl_x509_parse($cert);
-	$now = time();
-	$validFrom = isset($certInfo['validFrom_time_t']) ? (int) $certInfo['validFrom_time_t'] : 0;
-	$validTo = isset($certInfo['validTo_time_t']) ? (int) $certInfo['validTo_time_t'] : 0;
-	if (($validFrom > 0 && $now < $validFrom) || ($validTo > 0 && $now > $validTo)) {
-		openssl_x509_free($cert);
-		dol_syslog("VERIFACTU: Certificate is outside its X.509 validity period", LOG_ERR);
-		$GLOBALS['verifactu_cert_error'] = "Certificate is outside its X.509 validity period";
 		return false;
 	}
 

--- a/lib/functions/functions.configuration.php
+++ b/lib/functions/functions.configuration.php
@@ -287,36 +287,6 @@ function isVerifactuCertificateFingerprintUnique($fingerprint, $entity = null, &
 }
 
 /**
- * Check whether an entity already has invoices in its VeriFactu fiscal chain.
- *
- * @param int|null $entity Current entity by default
- * @return bool            True when at least one fingerprint was generated
- */
-function hasVerifactuFiscalRecords($entity = null)
-{
-	global $conf, $db;
-
-	$entity = ($entity === null ? (int) $conf->entity : (int) $entity);
-	$sql = "SELECT 1 AS found";
-	$sql .= " FROM " . MAIN_DB_PREFIX . "facture AS f";
-	$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "facture_extrafields AS fe ON fe.fk_object = f.rowid";
-	$sql .= " WHERE f.entity = " . $entity;
-	$sql .= " AND fe.verifactu_huella IS NOT NULL AND fe.verifactu_huella <> ''";
-	$sql .= $db->plimit(1);
-	$resql = $db->query($sql);
-	if (!$resql) {
-		// Fail closed: fiscal identity changes must not be allowed when chain state
-		// cannot be verified.
-		dol_syslog(__FUNCTION__ . ': unable to inspect the fiscal chain: ' . $db->lasterror(), LOG_ERR);
-		return true;
-	}
-
-	$hasRecords = (bool) $db->fetch_object($resql);
-	$db->free($resql);
-	return $hasRecords;
-}
-
-/**
  * Gets the billing system configuration for AEAT
  *
  * @return array System configuration array

--- a/lib/functions/functions.configuration.php
+++ b/lib/functions/functions.configuration.php
@@ -109,6 +109,58 @@ function calculateVerifactuIntegrityChecksums($moduleDirectory)
 	return hash('sha256', json_encode($files));
 }
 
+if (!function_exists('isEntitySharingAllowed')) {
+	/**
+	 * Check that a MultiCompany element is not shared from or with an entity.
+	 *
+	 * The function is declared conditionally so a future Dolibarr core implementation
+	 * can provide the same API without a function name collision.
+	 *
+	 * @param string   $element Element key used by MultiCompany
+	 * @param int|null $entity  Entity to check, current entity by default
+	 * @return bool             True when the element is isolated
+	 */
+	function isEntitySharingAllowed($element, $entity = null)
+	{
+		global $conf, $db;
+
+		if (!isModEnabled('multicompany')) {
+			return true;
+		}
+		$sharingConstant = 'MULTICOMPANY_' . strtoupper($element) . '_SHARING_ENABLED';
+		if (!getDolGlobalInt($sharingConstant)) {
+			return true;
+		}
+
+		$entity = ($entity === null ? (int) $conf->entity : (int) $entity);
+		$sql = "SELECT rowid, options FROM " . MAIN_DB_PREFIX . "entity";
+		$resql = $db->query($sql);
+		if (!$resql) {
+			dol_syslog(__FUNCTION__ . ': unable to inspect MultiCompany sharing configuration: ' . $db->lasterror(), LOG_ERR);
+			return false;
+		}
+
+		$allowed = true;
+		while ($obj = $db->fetch_object($resql)) {
+			$options = (!empty($obj->options) ? json_decode($obj->options, true) : array());
+			$sharedEntities = $options['sharings'][$element] ?? array();
+			if (!is_array($sharedEntities)) {
+				continue;
+			}
+
+			// Outgoing sharing from the checked entity or incoming sharing to it.
+			if (((int) $obj->rowid === $entity && !empty($sharedEntities))
+				|| ((int) $obj->rowid !== $entity && in_array((string) $entity, array_map('strval', $sharedEntities), true))) {
+				$allowed = false;
+				break;
+			}
+		}
+
+		$db->free($resql);
+		return $allowed;
+	}
+}
+
 /**
  * Gets the billing system configuration for AEAT
  *

--- a/lib/functions/functions.configuration.php
+++ b/lib/functions/functions.configuration.php
@@ -121,10 +121,9 @@ function getSystemConfig()
 	$issuerName = $conf->global->VERIFACTU_HOLDER_COMPANY_NAME ?? '';
 	$issuerNif = $conf->global->VERIFACTU_HOLDER_NIF ?? '';
 	$installationNumber = $dolibarr_main_instance_unique_id . '_' . $conf->entity;
-	$supportsMultipleTaxpayers = isModEnabled('multicompany');
 	$hasMultipleTaxpayers = false;
 
-	if ($supportsMultipleTaxpayers) {
+	if (isModEnabled('multicompany')) {
 		$sql = "SELECT COUNT(DISTINCT e.rowid) as nb";
 		$sql .= " FROM " . MAIN_DB_PREFIX . "entity AS e";
 		$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "const AS c ON c.entity = e.rowid";
@@ -149,7 +148,7 @@ function getSystemConfig()
 		'Version' => (defined('DOL_VERSION') ? DOL_VERSION : '1.0.0'),
 		'NumeroInstalacion' => $installationNumber,
 		'TipoUsoPosibleSoloVerifactu' => 'S',
-		'TipoUsoPosibleMultiOT' => ($supportsMultipleTaxpayers ? 'S' : 'N'),
+		'TipoUsoPosibleMultiOT' => ($hasMultipleTaxpayers ? 'S' : 'N'),
 		'IndicadorMultiplesOT' => ($hasMultipleTaxpayers ? 'S' : 'N'),
 	];
 }

--- a/lib/functions/functions.configuration.php
+++ b/lib/functions/functions.configuration.php
@@ -162,6 +162,29 @@ if (!function_exists('isEntitySharingAllowed')) {
 }
 
 /**
+ * Check all resources that VeriFactu requires to be isolated per legal entity.
+ *
+ * @param int|null    $entity        Entity to check, current entity by default
+ * @param string|null $sharedElement Receives the first incompatible element
+ * @return bool                      True when every fiscal resource is isolated
+ */
+function isVerifactuEntityIsolated($entity = null, &$sharedElement = null)
+{
+	global $conf;
+
+	$entity = ($entity === null ? (int) $conf->entity : (int) $entity);
+	$sharedElement = null;
+	foreach (array('invoice', 'invoicenumber', 'bankaccount') as $element) {
+		if (!isEntitySharingAllowed($element, $entity)) {
+			$sharedElement = $element;
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
  * Gets the billing system configuration for AEAT
  *
  * @return array System configuration array

--- a/lib/functions/functions.configuration.php
+++ b/lib/functions/functions.configuration.php
@@ -185,6 +185,108 @@ function isVerifactuEntityIsolated($entity = null, &$sharedElement = null)
 }
 
 /**
+ * Normalize a taxpayer identifier for comparisons between entities.
+ *
+ * @param string $taxId Tax identifier
+ * @return string Normalized identifier
+ */
+function normalizeVerifactuTaxIdentifier($taxId)
+{
+	return strtoupper(preg_replace('/[^A-Z0-9]/i', '', trim((string) $taxId)));
+}
+
+/**
+ * Check that no other VeriFactu-enabled entity uses the same taxpayer NIF.
+ *
+ * @param string   $taxId          Taxpayer NIF to check
+ * @param int|null $entity         Current entity by default
+ * @param int|null $conflictEntity Receives the conflicting entity id
+ * @return bool                    True when the NIF is unique
+ */
+function isVerifactuTaxIdentityUnique($taxId, $entity = null, &$conflictEntity = null)
+{
+	global $conf, $db;
+
+	$entity = ($entity === null ? (int) $conf->entity : (int) $entity);
+	$taxId = normalizeVerifactuTaxIdentifier($taxId);
+	$conflictEntity = null;
+	if ($taxId === '' || !isModEnabled('multicompany')) {
+		return true;
+	}
+
+	$sql = "SELECT taxpayer.entity, taxpayer.value";
+	$sql .= " FROM " . MAIN_DB_PREFIX . "const AS taxpayer";
+	$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "const AS module ON module.entity = taxpayer.entity";
+	$sql .= " AND module.name = 'MAIN_MODULE_VERIFACTU' AND module.value = '1'";
+	$sql .= " WHERE taxpayer.name = 'VERIFACTU_HOLDER_NIF'";
+	$sql .= " AND taxpayer.entity <> " . $entity;
+	$resql = $db->query($sql);
+	if (!$resql) {
+		dol_syslog(__FUNCTION__ . ': unable to inspect taxpayer identities: ' . $db->lasterror(), LOG_ERR);
+		$conflictEntity = -1;
+		return false;
+	}
+
+	$unique = true;
+	while ($obj = $db->fetch_object($resql)) {
+		if (normalizeVerifactuTaxIdentifier($obj->value) === $taxId) {
+			$conflictEntity = (int) $obj->entity;
+			$unique = false;
+			break;
+		}
+	}
+	$db->free($resql);
+
+	return $unique;
+}
+
+/**
+ * Check that no other VeriFactu-enabled entity uses the same X.509 certificate.
+ *
+ * @param string   $fingerprint    SHA-256 certificate fingerprint
+ * @param int|null $entity         Current entity by default
+ * @param int|null $conflictEntity Receives the conflicting entity id
+ * @return bool                    True when the certificate is unique
+ */
+function isVerifactuCertificateFingerprintUnique($fingerprint, $entity = null, &$conflictEntity = null)
+{
+	global $conf, $db;
+
+	$entity = ($entity === null ? (int) $conf->entity : (int) $entity);
+	$fingerprint = strtolower(preg_replace('/[^a-f0-9]/i', '', (string) $fingerprint));
+	$conflictEntity = null;
+	if ($fingerprint === '' || !isModEnabled('multicompany')) {
+		return true;
+	}
+
+	$sql = "SELECT certificate.entity, certificate.value";
+	$sql .= " FROM " . MAIN_DB_PREFIX . "const AS certificate";
+	$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "const AS module ON module.entity = certificate.entity";
+	$sql .= " AND module.name = 'MAIN_MODULE_VERIFACTU' AND module.value = '1'";
+	$sql .= " WHERE certificate.name = 'VERIFACTU_CERTIFICATE_FINGERPRINT_SHA256'";
+	$sql .= " AND certificate.entity <> " . $entity;
+	$resql = $db->query($sql);
+	if (!$resql) {
+		dol_syslog(__FUNCTION__ . ': unable to inspect certificate fingerprints: ' . $db->lasterror(), LOG_ERR);
+		$conflictEntity = -1;
+		return false;
+	}
+
+	$unique = true;
+	while ($obj = $db->fetch_object($resql)) {
+		$otherFingerprint = strtolower(preg_replace('/[^a-f0-9]/i', '', (string) $obj->value));
+		if ($otherFingerprint === $fingerprint) {
+			$conflictEntity = (int) $obj->entity;
+			$unique = false;
+			break;
+		}
+	}
+	$db->free($resql);
+
+	return $unique;
+}
+
+/**
  * Gets the billing system configuration for AEAT
  *
  * @return array System configuration array

--- a/lib/functions/functions.configuration.php
+++ b/lib/functions/functions.configuration.php
@@ -125,9 +125,12 @@ function getSystemConfig()
 	$hasMultipleTaxpayers = false;
 
 	if ($supportsMultipleTaxpayers) {
-		$sql = "SELECT COUNT(rowid) as nb";
-		$sql .= " FROM " . MAIN_DB_PREFIX . "entity";
-		$sql .= " WHERE active = 1";
+		$sql = "SELECT COUNT(DISTINCT e.rowid) as nb";
+		$sql .= " FROM " . MAIN_DB_PREFIX . "entity AS e";
+		$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "const AS c ON c.entity = e.rowid";
+		$sql .= " AND c.name = 'MAIN_MODULE_VERIFACTU'";
+		$sql .= " AND c.value = '1'";
+		$sql .= " WHERE e.active = 1";
 		$resql = $db->query($sql);
 		if ($resql) {
 			$obj = $db->fetch_object($resql);

--- a/lib/functions/functions.configuration.php
+++ b/lib/functions/functions.configuration.php
@@ -287,6 +287,36 @@ function isVerifactuCertificateFingerprintUnique($fingerprint, $entity = null, &
 }
 
 /**
+ * Check whether an entity already has invoices in its VeriFactu fiscal chain.
+ *
+ * @param int|null $entity Current entity by default
+ * @return bool            True when at least one fingerprint was generated
+ */
+function hasVerifactuFiscalRecords($entity = null)
+{
+	global $conf, $db;
+
+	$entity = ($entity === null ? (int) $conf->entity : (int) $entity);
+	$sql = "SELECT 1 AS found";
+	$sql .= " FROM " . MAIN_DB_PREFIX . "facture AS f";
+	$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "facture_extrafields AS fe ON fe.fk_object = f.rowid";
+	$sql .= " WHERE f.entity = " . $entity;
+	$sql .= " AND fe.verifactu_huella IS NOT NULL AND fe.verifactu_huella <> ''";
+	$sql .= $db->plimit(1);
+	$resql = $db->query($sql);
+	if (!$resql) {
+		// Fail closed: fiscal identity changes must not be allowed when chain state
+		// cannot be verified.
+		dol_syslog(__FUNCTION__ . ': unable to inspect the fiscal chain: ' . $db->lasterror(), LOG_ERR);
+		return true;
+	}
+
+	$hasRecords = (bool) $db->fetch_object($resql);
+	$db->free($resql);
+	return $hasRecords;
+}
+
+/**
  * Gets the billing system configuration for AEAT
  *
  * @return array System configuration array

--- a/lib/functions/functions.configuration.php
+++ b/lib/functions/functions.configuration.php
@@ -116,11 +116,27 @@ function calculateVerifactuIntegrityChecksums($moduleDirectory)
  */
 function getSystemConfig()
 {
-	global $conf, $dolibarr_main_instance_unique_id;
+	global $conf, $db, $dolibarr_main_instance_unique_id;
 
 	$issuerName = $conf->global->VERIFACTU_HOLDER_COMPANY_NAME ?? '';
 	$issuerNif = $conf->global->VERIFACTU_HOLDER_NIF ?? '';
 	$installationNumber = $dolibarr_main_instance_unique_id . '_' . $conf->entity;
+	$supportsMultipleTaxpayers = isModEnabled('multicompany');
+	$hasMultipleTaxpayers = false;
+
+	if ($supportsMultipleTaxpayers) {
+		$sql = "SELECT COUNT(rowid) as nb";
+		$sql .= " FROM " . MAIN_DB_PREFIX . "entity";
+		$sql .= " WHERE active = 1";
+		$resql = $db->query($sql);
+		if ($resql) {
+			$obj = $db->fetch_object($resql);
+			$hasMultipleTaxpayers = ((int) $obj->nb > 1);
+			$db->free($resql);
+		} else {
+			dol_syslog(__FUNCTION__ . ': unable to count active MultiCompany entities: ' . $db->lasterror(), LOG_WARNING);
+		}
+	}
 
 	return [
 		'NombreRazon' => $issuerName,
@@ -130,8 +146,8 @@ function getSystemConfig()
 		'Version' => (defined('DOL_VERSION') ? DOL_VERSION : '1.0.0'),
 		'NumeroInstalacion' => $installationNumber,
 		'TipoUsoPosibleSoloVerifactu' => 'S',
-		'TipoUsoPosibleMultiOT' => 'N',
-		'IndicadorMultiplesOT' => 'N',
+		'TipoUsoPosibleMultiOT' => ($supportsMultipleTaxpayers ? 'S' : 'N'),
+		'IndicadorMultiplesOT' => ($hasMultipleTaxpayers ? 'S' : 'N'),
 	];
 }
 

--- a/lib/functions/functions.hash.php
+++ b/lib/functions/functions.hash.php
@@ -40,7 +40,9 @@ function getLastInvoiceHash()
 	$sql .= "DATE_FORMAT(f.datef, '%d-%m-%Y') as invoice_date"; // Format dd-mm-yyyy for Verifactu
 	$sql .= " FROM " . MAIN_DB_PREFIX . "facture f";
 	$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "facture_extrafields fe ON f.rowid = fe.fk_object";
-	$sql .= " WHERE f.entity = " . getEntity('invoice');
+	// VeriFactu chains are specific to the active legal entity and must never
+	// include invoices shared from another entity.
+	$sql .= " WHERE f.entity = " . ((int) $conf->entity);
 	$sql .= " AND fe.verifactu_huella IS NOT NULL AND fe.verifactu_huella != '' AND fe.verifactu_entorno = '" . $db->escape($environment) . "'";
 	$sql .= " AND f.fk_statut > 0"; // Only validated invoices
 	$sql .= " ORDER BY f.rowid DESC LIMIT 1";

--- a/lib/functions/functions.query.php
+++ b/lib/functions/functions.query.php
@@ -78,6 +78,11 @@ function execVERIFACTUQuery($filtroConsulta)
 		$environment = getEnvironment();
 		$issuerNif = $conf->global->VERIFACTU_HOLDER_NIF ?? '';
 		$issuerName = $conf->global->VERIFACTU_HOLDER_COMPANY_NAME ?? '';
+		$conflictEntity = null;
+		if (!isVerifactuTaxIdentityUnique($issuerNif, (int) $conf->entity, $conflictEntity)) {
+			setEventMessage($langs->trans('VERIFACTU_TAX_IDENTITY_ALREADY_USED', $conflictEntity), 'errors');
+			return false;
+		}
 
 		dol_syslog("VERIFACTU: Issuer NIF: $issuerNif, Name: $issuerName", LOG_DEBUG);
 

--- a/lib/functions/functions.submission.php
+++ b/lib/functions/functions.submission.php
@@ -126,6 +126,11 @@ function execVERIFACTUCall(Facture $facture, $actionVERIFACTU = 'Alta')
 		$environment = getEnvironment();
 		$issuerNif = $conf->global->VERIFACTU_HOLDER_NIF ?? '';
 		$issuerName = $conf->global->VERIFACTU_HOLDER_COMPANY_NAME ?? '';
+		$conflictEntity = null;
+		if (!isVerifactuTaxIdentityUnique($issuerNif, (int) $conf->entity, $conflictEntity)) {
+			setEventMessage($langs->trans('VERIFACTU_TAX_IDENTITY_ALREADY_USED', $conflictEntity), 'errors');
+			return false;
+		}
 
 		// Get certificate configuration
 		$certOptions = getCertificateOptions();

--- a/tests/EntitySharingIsolationTest.php
+++ b/tests/EntitySharingIsolationTest.php
@@ -60,11 +60,6 @@ class FakeEntitySharingDatabase
 	{
 		return '';
 	}
-
-	public function plimit($limit)
-	{
-		return ' LIMIT ' . (int) $limit;
-	}
 }
 
 function sharingOptions(array $sharings)
@@ -162,18 +157,6 @@ $db = new FakeEntitySharingDatabase(array(
 ));
 if (!isVerifactuCertificateFingerprintUnique($fingerprint, 2, $conflictEntity) || $conflictEntity !== null) {
 	fwrite(STDERR, "Different certificate fingerprints must be accepted\n");
-	exit(1);
-}
-
-$db = new FakeEntitySharingDatabase(array(array('found' => 1)));
-if (!hasVerifactuFiscalRecords(2)) {
-	fwrite(STDERR, "An existing fiscal fingerprint must lock the taxpayer identity\n");
-	exit(1);
-}
-
-$db = new FakeEntitySharingDatabase(array());
-if (hasVerifactuFiscalRecords(2)) {
-	fwrite(STDERR, "An entity without fiscal fingerprints must remain configurable\n");
 	exit(1);
 }
 

--- a/tests/EntitySharingIsolationTest.php
+++ b/tests/EntitySharingIsolationTest.php
@@ -1,0 +1,122 @@
+<?php
+
+if (!defined('MAIN_DB_PREFIX')) {
+	define('MAIN_DB_PREFIX', 'llx_');
+}
+if (!defined('LOG_ERR')) {
+	define('LOG_ERR', 3);
+}
+
+if (!function_exists('isModEnabled')) {
+	function isModEnabled($module)
+	{
+		return $module === 'multicompany';
+	}
+}
+if (!function_exists('dol_syslog')) {
+	function dol_syslog($message, $level = 0)
+	{
+	}
+}
+if (!function_exists('getDolGlobalInt')) {
+	function getDolGlobalInt($name)
+	{
+		global $enabledSharingConstants;
+		return !empty($enabledSharingConstants[$name]) ? 1 : 0;
+	}
+}
+
+require_once __DIR__ . '/../lib/functions/functions.configuration.php';
+
+class FakeEntitySharingDatabase
+{
+	private $rows;
+	private $position = 0;
+
+	public function __construct(array $rows)
+	{
+		$this->rows = $rows;
+	}
+
+	public function query($sql)
+	{
+		$this->position = 0;
+		return true;
+	}
+
+	public function fetch_object($result)
+	{
+		if (!isset($this->rows[$this->position])) {
+			return false;
+		}
+		return (object) $this->rows[$this->position++];
+	}
+
+	public function free($result)
+	{
+	}
+
+	public function lasterror()
+	{
+		return '';
+	}
+}
+
+function sharingOptions(array $sharings)
+{
+	return json_encode(array('sharings' => $sharings));
+}
+
+$conf = (object) array('entity' => 2);
+$enabledSharingConstants = array(
+	'MULTICOMPANY_INVOICE_SHARING_ENABLED' => 1,
+	'MULTICOMPANY_INVOICENUMBER_SHARING_ENABLED' => 1,
+	'MULTICOMPANY_BANKACCOUNT_SHARING_ENABLED' => 1,
+);
+
+$db = new FakeEntitySharingDatabase(array(
+	array('rowid' => 1, 'options' => sharingOptions(array())),
+	array('rowid' => 2, 'options' => sharingOptions(array())),
+));
+if (!isEntitySharingAllowed('invoice', 2)) {
+	fwrite(STDERR, "An isolated entity must allow invoice use\n");
+	exit(1);
+}
+
+$enabledSharingConstants['MULTICOMPANY_INVOICE_SHARING_ENABLED'] = 0;
+$db = new FakeEntitySharingDatabase(array(
+	array('rowid' => 2, 'options' => sharingOptions(array('invoice' => array('1')))),
+));
+if (!isEntitySharingAllowed('invoice', 2)) {
+	fwrite(STDERR, "Stored sharing must be ignored when the feature is disabled\n");
+	exit(1);
+}
+$enabledSharingConstants['MULTICOMPANY_INVOICE_SHARING_ENABLED'] = 1;
+
+$db = new FakeEntitySharingDatabase(array(
+	array('rowid' => 2, 'options' => sharingOptions(array('invoice' => array('1')))),
+));
+if (isEntitySharingAllowed('invoice', 2)) {
+	fwrite(STDERR, "Outgoing invoice sharing must be rejected\n");
+	exit(1);
+}
+
+$db = new FakeEntitySharingDatabase(array(
+	array('rowid' => 1, 'options' => sharingOptions(array('bankaccount' => array('2')))),
+	array('rowid' => 2, 'options' => sharingOptions(array())),
+));
+if (isEntitySharingAllowed('bankaccount', 2)) {
+	fwrite(STDERR, "Incoming bank account sharing must be rejected\n");
+	exit(1);
+}
+
+$db = new FakeEntitySharingDatabase(array(
+	array('rowid' => 1, 'options' => sharingOptions(array('invoicenumber' => array(2)))),
+	array('rowid' => 2, 'options' => sharingOptions(array())),
+));
+if (isEntitySharingAllowed('invoicenumber', 2)) {
+	fwrite(STDERR, "Numeric incoming invoice-number sharing must be rejected\n");
+	exit(1);
+}
+
+echo "Entity sharing isolation tests passed\n";

--- a/tests/EntitySharingIsolationTest.php
+++ b/tests/EntitySharingIsolationTest.php
@@ -127,4 +127,37 @@ if (isVerifactuEntityIsolated(2, $sharedElement) || $sharedElement !== 'invoicen
 	exit(1);
 }
 
+$db = new FakeEntitySharingDatabase(array(
+	array('entity' => 1, 'value' => ' B-12345678 '),
+));
+if (isVerifactuTaxIdentityUnique('b12345678', 2, $conflictEntity) || $conflictEntity !== 1) {
+	fwrite(STDERR, "Equivalent normalized taxpayer identities must be rejected\n");
+	exit(1);
+}
+
+$db = new FakeEntitySharingDatabase(array(
+	array('entity' => 1, 'value' => 'B12345678'),
+));
+if (!isVerifactuTaxIdentityUnique('A87654321', 2, $conflictEntity) || $conflictEntity !== null) {
+	fwrite(STDERR, "Different taxpayer identities must be accepted\n");
+	exit(1);
+}
+
+$fingerprint = str_repeat('ab', 32);
+$db = new FakeEntitySharingDatabase(array(
+	array('entity' => 3, 'value' => strtoupper(implode(':', str_split($fingerprint, 2)))),
+));
+if (isVerifactuCertificateFingerprintUnique($fingerprint, 2, $conflictEntity) || $conflictEntity !== 3) {
+	fwrite(STDERR, "Equivalent certificate fingerprints must be rejected\n");
+	exit(1);
+}
+
+$db = new FakeEntitySharingDatabase(array(
+	array('entity' => 3, 'value' => str_repeat('cd', 32)),
+));
+if (!isVerifactuCertificateFingerprintUnique($fingerprint, 2, $conflictEntity) || $conflictEntity !== null) {
+	fwrite(STDERR, "Different certificate fingerprints must be accepted\n");
+	exit(1);
+}
+
 echo "Entity sharing isolation tests passed\n";

--- a/tests/EntitySharingIsolationTest.php
+++ b/tests/EntitySharingIsolationTest.php
@@ -60,6 +60,11 @@ class FakeEntitySharingDatabase
 	{
 		return '';
 	}
+
+	public function plimit($limit)
+	{
+		return ' LIMIT ' . (int) $limit;
+	}
 }
 
 function sharingOptions(array $sharings)
@@ -157,6 +162,18 @@ $db = new FakeEntitySharingDatabase(array(
 ));
 if (!isVerifactuCertificateFingerprintUnique($fingerprint, 2, $conflictEntity) || $conflictEntity !== null) {
 	fwrite(STDERR, "Different certificate fingerprints must be accepted\n");
+	exit(1);
+}
+
+$db = new FakeEntitySharingDatabase(array(array('found' => 1)));
+if (!hasVerifactuFiscalRecords(2)) {
+	fwrite(STDERR, "An existing fiscal fingerprint must lock the taxpayer identity\n");
+	exit(1);
+}
+
+$db = new FakeEntitySharingDatabase(array());
+if (hasVerifactuFiscalRecords(2)) {
+	fwrite(STDERR, "An entity without fiscal fingerprints must remain configurable\n");
 	exit(1);
 }
 

--- a/tests/EntitySharingIsolationTest.php
+++ b/tests/EntitySharingIsolationTest.php
@@ -82,6 +82,10 @@ if (!isEntitySharingAllowed('invoice', 2)) {
 	fwrite(STDERR, "An isolated entity must allow invoice use\n");
 	exit(1);
 }
+if (!isVerifactuEntityIsolated(2, $sharedElement) || $sharedElement !== null) {
+	fwrite(STDERR, "All isolated VeriFactu resources must pass the aggregate check\n");
+	exit(1);
+}
 
 $enabledSharingConstants['MULTICOMPANY_INVOICE_SHARING_ENABLED'] = 0;
 $db = new FakeEntitySharingDatabase(array(
@@ -116,6 +120,10 @@ $db = new FakeEntitySharingDatabase(array(
 ));
 if (isEntitySharingAllowed('invoicenumber', 2)) {
 	fwrite(STDERR, "Numeric incoming invoice-number sharing must be rejected\n");
+	exit(1);
+}
+if (isVerifactuEntityIsolated(2, $sharedElement) || $sharedElement !== 'invoicenumber') {
+	fwrite(STDERR, "Aggregate isolation check must report the incompatible resource\n");
 	exit(1);
 }
 

--- a/tests/MultipleActiveEntitiesTest.php
+++ b/tests/MultipleActiveEntitiesTest.php
@@ -46,6 +46,11 @@ $dolibarr_main_instance_unique_id = 'test-instance';
 $db = new FakeVerifactuEntitiesDatabase(2);
 
 $config = getSystemConfig();
+if ($config['TipoUsoPosibleMultiOT'] !== 'S') {
+	fwrite(STDERR, "Two active VeriFactu entities must set TipoUsoPosibleMultiOT to S\n");
+	exit(1);
+}
+
 if ($config['IndicadorMultiplesOT'] !== 'S') {
 	fwrite(STDERR, "Two active VeriFactu entities must set IndicadorMultiplesOT to S\n");
 	exit(1);
@@ -65,6 +70,11 @@ if (stripos($db->lastQuery, 'country') !== false) {
 
 $db = new FakeVerifactuEntitiesDatabase(1);
 $config = getSystemConfig();
+if ($config['TipoUsoPosibleMultiOT'] !== 'N') {
+	fwrite(STDERR, "One active VeriFactu entity must set TipoUsoPosibleMultiOT to N\n");
+	exit(1);
+}
+
 if ($config['IndicadorMultiplesOT'] !== 'N') {
 	fwrite(STDERR, "One active VeriFactu entity must set IndicadorMultiplesOT to N\n");
 	exit(1);

--- a/tests/MultipleActiveEntitiesTest.php
+++ b/tests/MultipleActiveEntitiesTest.php
@@ -1,0 +1,73 @@
+<?php
+
+if (!defined('MAIN_DB_PREFIX')) {
+	define('MAIN_DB_PREFIX', 'llx_');
+}
+
+if (!function_exists('isModEnabled')) {
+	function isModEnabled($module)
+	{
+		return $module === 'multicompany';
+	}
+}
+
+require_once __DIR__ . '/../lib/functions/functions.configuration.php';
+
+class FakeVerifactuEntitiesDatabase
+{
+	private $entityCount;
+	public $lastQuery = '';
+
+	public function __construct($entityCount)
+	{
+		$this->entityCount = $entityCount;
+	}
+
+	public function query($sql)
+	{
+		$this->lastQuery = $sql;
+		return true;
+	}
+
+	public function fetch_object($result)
+	{
+		return (object) ['nb' => $this->entityCount];
+	}
+
+	public function free($result)
+	{
+	}
+}
+
+$conf = new stdClass();
+$conf->entity = 1;
+$conf->global = new stdClass();
+$dolibarr_main_instance_unique_id = 'test-instance';
+$db = new FakeVerifactuEntitiesDatabase(2);
+
+$config = getSystemConfig();
+if ($config['IndicadorMultiplesOT'] !== 'S') {
+	fwrite(STDERR, "Two active VeriFactu entities must set IndicadorMultiplesOT to S\n");
+	exit(1);
+}
+
+if (strpos($db->lastQuery, 'e.active = 1') === false
+	|| strpos($db->lastQuery, "c.name = 'MAIN_MODULE_VERIFACTU'") === false
+	|| strpos($db->lastQuery, "c.value = '1'") === false) {
+	fwrite(STDERR, "Only active entities with VeriFactu enabled must be counted\n");
+	exit(1);
+}
+
+if (stripos($db->lastQuery, 'country') !== false) {
+	fwrite(STDERR, "Entity nationality must not exclude an active VeriFactu entity\n");
+	exit(1);
+}
+
+$db = new FakeVerifactuEntitiesDatabase(1);
+$config = getSystemConfig();
+if ($config['IndicadorMultiplesOT'] !== 'N') {
+	fwrite(STDERR, "One active VeriFactu entity must set IndicadorMultiplesOT to N\n");
+	exit(1);
+}
+
+echo "Multiple active VeriFactu entity tests passed\n";

--- a/verifactuindex.php
+++ b/verifactuindex.php
@@ -86,7 +86,7 @@ $sqlByStatus = "SELECT fe.verifactu_estado as estado, COUNT(*) as total";
 $sqlByStatus .= " FROM " . MAIN_DB_PREFIX . "facture f";
 $sqlByStatus .= " INNER JOIN " . MAIN_DB_PREFIX . "facture_extrafields fe ON f.rowid = fe.fk_object";
 $sqlByStatus .= " WHERE fe.verifactu_estado IS NOT NULL AND fe.verifactu_estado != ''";
-$sqlByStatus .= " AND f.entity IN (" . getEntity('invoice') . ")";
+$sqlByStatus .= " AND f.entity = " . ((int) $conf->entity);
 $sqlByStatus .= " GROUP BY fe.verifactu_estado";
 $sqlByStatus .= " ORDER BY total DESC";
 
@@ -106,7 +106,7 @@ $sqlErrors = "SELECT COUNT(*) as total FROM " . MAIN_DB_PREFIX . "facture f";
 $sqlErrors .= " INNER JOIN " . MAIN_DB_PREFIX . "facture_extrafields fe ON f.rowid = fe.fk_object";
 $sqlErrors .= " WHERE fe.verifactu_error IS NOT NULL AND fe.verifactu_error != ''";
 $sqlErrors .= " AND f.fk_statut > 0";
-$sqlErrors .= " AND f.entity IN (" . getEntity('invoice') . ")";
+$sqlErrors .= " AND f.entity = " . ((int) $conf->entity);
 $resqlErrors = $db->query($sqlErrors);
 $totalErrors = 0;
 if ($resqlErrors) {
@@ -122,7 +122,7 @@ $sqlByMonth .= " FROM " . MAIN_DB_PREFIX . "facture f";
 $sqlByMonth .= " INNER JOIN " . MAIN_DB_PREFIX . "facture_extrafields fe ON f.rowid = fe.fk_object";
 $sqlByMonth .= " WHERE fe.verifactu_estado IS NOT NULL AND fe.verifactu_estado != ''";
 $sqlByMonth .= " AND YEAR(f.datef) = " . $currentYear;
-$sqlByMonth .= " AND f.entity IN (" . getEntity('invoice') . ")";
+$sqlByMonth .= " AND f.entity = " . ((int) $conf->entity);
 $sqlByMonth .= " GROUP BY MONTH(f.datef)";
 $sqlByMonth .= " ORDER BY MONTH(f.datef)";
 
@@ -141,7 +141,7 @@ $sqlLastSent .= " FROM " . MAIN_DB_PREFIX . "facture f";
 $sqlLastSent .= " INNER JOIN " . MAIN_DB_PREFIX . "facture_extrafields fe ON f.rowid = fe.fk_object";
 $sqlLastSent .= " LEFT JOIN " . MAIN_DB_PREFIX . "societe s ON f.fk_soc = s.rowid";
 $sqlLastSent .= " WHERE fe.verifactu_estado IS NOT NULL AND fe.verifactu_estado != ''";
-$sqlLastSent .= " AND f.entity IN (" . getEntity('invoice') . ")";
+$sqlLastSent .= " AND f.entity = " . ((int) $conf->entity);
 $sqlLastSent .= " ORDER BY fe.verifactu_ultimafecha_modificacion DESC";
 $sqlLastSent .= " LIMIT 5";
 
@@ -161,7 +161,7 @@ $sqlWithErrors .= " INNER JOIN " . MAIN_DB_PREFIX . "facture_extrafields fe ON f
 $sqlWithErrors .= " LEFT JOIN " . MAIN_DB_PREFIX . "societe s ON f.fk_soc = s.rowid";
 $sqlWithErrors .= " WHERE fe.verifactu_error IS NOT NULL AND fe.verifactu_error != ''";
 $sqlWithErrors .= " AND f.fk_statut > 0";
-$sqlWithErrors .= " AND f.entity IN (" . getEntity('invoice') . ")";
+$sqlWithErrors .= " AND f.entity = " . ((int) $conf->entity);
 $sqlWithErrors .= " ORDER BY f.datef DESC";
 $sqlWithErrors .= " LIMIT 5";
 
@@ -181,7 +181,7 @@ $sqlPending .= " LEFT JOIN " . MAIN_DB_PREFIX . "facture_extrafields fe ON f.row
 $sqlPending .= " LEFT JOIN " . MAIN_DB_PREFIX . "societe s ON f.fk_soc = s.rowid";
 $sqlPending .= " WHERE f.fk_statut = 1"; // Validated
 $sqlPending .= " AND (fe.verifactu_estado IS NULL OR fe.verifactu_estado = '')";
-$sqlPending .= " AND f.entity IN (" . getEntity('invoice') . ")";
+$sqlPending .= " AND f.entity = " . ((int) $conf->entity);
 $sqlPending .= " ORDER BY f.datef DESC";
 $sqlPending .= " LIMIT 5";
 
@@ -202,7 +202,7 @@ $sqlPendingCount .= " FROM " . MAIN_DB_PREFIX . "facture f";
 $sqlPendingCount .= " LEFT JOIN " . MAIN_DB_PREFIX . "facture_extrafields fe ON f.rowid = fe.fk_object";
 $sqlPendingCount .= " WHERE f.fk_statut = 1";
 $sqlPendingCount .= " AND (fe.verifactu_estado IS NULL OR fe.verifactu_estado = '')";
-$sqlPendingCount .= " AND f.entity IN (" . getEntity('invoice') . ")";
+$sqlPendingCount .= " AND f.entity = " . ((int) $conf->entity);
 $resqlPendingCount = $db->query($sqlPendingCount);
 if ($resqlPendingCount) {
 	$obj = $db->fetch_object($resqlPendingCount);

--- a/views/list.facture.php
+++ b/views/list.facture.php
@@ -748,7 +748,8 @@ $reshook = $hookmanager->executeHooks('printFieldListFrom', $parameters, $object
 $sql .= $hookmanager->resPrint;
 
 $sql .= ' WHERE f.fk_soc = s.rowid';
-$sql .= ' AND f.entity IN (' . getEntity('invoice') . ')';
+// VeriFactu data must not include invoices shared from another legal entity.
+$sql .= ' AND f.entity = ' . ((int) $conf->entity);
 if (empty($user->rights->societe->client->voir) && !$socid) {
 	$sql .= " AND s.rowid = sc.fk_soc AND sc.fk_user = " . ((int) $user->id);
 }

--- a/views/query.facture.php
+++ b/views/query.facture.php
@@ -255,6 +255,7 @@ $consultaQuery->setFiscalPeriod($search_year, $search_month);
 if ($search_facture) {
 	// Search for the real invoice date in database to improve search
 	$sql = "SELECT date_creation, datef FROM " . MAIN_DB_PREFIX . "facture WHERE ref = '" . $db->escape($search_facture) . "'";
+	$sql .= " AND entity = " . ((int) $conf->entity);
 	$result = $db->query($sql);
 
 	$fechaFactura = null;


### PR DESCRIPTION
## Summary

This PR makes VeriFactu data, fiscal chains, configuration, and AEAT operations strictly entity-specific when Dolibarr MultiCompany is enabled.

It also prevents VeriFactu from operating with MultiCompany sharing settings that would break the legal separation between taxpayers.

## Changes

### Strict entity isolation

- scope the previous-invoice hash lookup to the active entity
- scope retries and pending/error invoice processing to the active entity
- scope dashboard statistics, integrity checks, invoice lists, and invoice searches to the active entity
- scope VeriFactu trigger checks and extrafield updates to the invoice entity
- initialize VeriFactu extrafields only for invoices belonging to the active entity
- create mandatory default extrafield values for the active entity instead of hard-coding entity 1
- keep configuration constants and document directories managed independently per entity

Fiscal queries use strict equality:

```php
entity = ((int) $conf->entity)
```

They do not rely on `getEntity('invoice')`, because that function may include entities shared by MultiCompany.

### MultiCompany sharing safeguards

VeriFactu requires the following resources to remain independent:

- customer invoices
- customer invoice numbering
- bank accounts

The new `isEntitySharingAllowed()` check detects both directions:

- resources shared by the VeriFactu entity with another entity
- resources shared by another entity with the VeriFactu entity

Stored sharing options are ignored when the corresponding MultiCompany sharing feature is disabled.

The aggregate `isVerifactuEntityIsolated()` check is applied:

- when VeriFactu is enabled
- again during every `BILL_VALIDATE` event

Rechecking during validation covers sharing changes made after activation, entities created from templates, API operations, imports, TakePOS flows, and mass validation.

Validation is also rejected when the invoice belongs to an entity different from the active entity.

### Taxpayer identity and certificate isolation

Each VeriFactu-enabled entity must represent a different taxpayer.

The taxpayer NIF is treated as the primary and mandatory cross-entity identity boundary. It is checked before configuration is saved, during module activation, during invoice validation, and before any AEAT submission/query.

The module now:

- normalizes and compares `VERIFACTU_HOLDER_NIF` against all other VeriFactu-enabled entities
- rejects a taxpayer NIF already used by another active VeriFactu entity before it can be saved or activated
- calculates the SHA-256 fingerprint of the public X.509 certificate
- rejects a certificate fingerprint already registered by another active VeriFactu entity
- stores the fingerprint as an entity-specific `VERIFACTU_CERTIFICATE_FINGERPRINT_SHA256` constant

Certificate files, passphrases, schemas, configuration constants, and output directories remain stored under the current entity context.

These checks are neutral when MultiCompany is not enabled, so standalone VeriFactu behavior is unchanged.

### AEAT Multi-OT indicators

Enabling MultiCompany alone no longer implies `TipoUsoPosibleMultiOT=S`.

Both indicators are enabled only when more than one active MultiCompany entity has VeriFactu enabled:

| Active entities with VeriFactu | TipoUsoPosibleMultiOT | IndicadorMultiplesOT |
| --- | --- | --- |
| 1 | N | N |
| More than 1 | S | S |

The installation number remains unique per entity.

## Defense in depth

The implementation uses three complementary safeguards:

1. activation-time configuration validation
2. validation-time isolation and taxpayer-identity enforcement
3. certificate fingerprint validation before AEAT operations
4. strict entity filters in every fiscal query

This means an incompatible sharing configuration, duplicated taxpayer identity, or reused certificate cannot enter the AEAT workflow even if introduced after module activation.

## Tests and validation

- added tests for one and multiple active VeriFactu entities
- added tests for incoming and outgoing invoice, invoice-number, and bank-account sharing
- added normalized taxpayer-NIF uniqueness tests
- verified duplicate NIF protection at configuration, activation, validation, submission, and query boundaries
- added normalized X.509 SHA-256 fingerprint uniqueness tests
- verified that disabled MultiCompany sharing features do not produce false positives
- verified aggregate isolation checks report the incompatible resource
- kept all 52 mass-validation assertions passing
- activated VeriFactu and its dependencies in entities 1 and 2 on Dolibarr 24.0
- verified 27 VeriFactu extrafields and 15 VeriFactu constants per entity
- verified separate output directories for both entities
- executed previous-invoice hash queries independently in both entity contexts
- ran PHP syntax checks on all module PHP files
- ran `git diff --check`

## Scope

This PR does not modify the external MultiCompany module. VeriFactu enforces isolation at activation and invoice validation time while retaining strict entity filtering at runtime.

A future generic Dolibarr core sharing API could allow MultiCompany to disable incompatible options directly in its administration interface, but it is not required for the fiscal isolation provided by this PR.

General taxpayer-identity immutability, certificate validity/permissions, and OpenSSL command hardening have been separated into PR #41.