### PR TITLE
FIX use Dolibarr invoice creation date column

### DIFF
--- a/views/query.facture.php
+++ b/views/query.facture.php
@@ -254,7 +254,7 @@ $consultaQuery->setFiscalPeriod($search_year, $search_month);
 // If a specific invoice is specified, add post-query filter
 if ($search_facture) {
 	// Search for the real invoice date in database to improve search
-	$sql = "SELECT date_creation, datef FROM " . MAIN_DB_PREFIX . "facture WHERE ref = '" . $db->escape($search_facture) . "'";
+	$sql = "SELECT datec AS date_creation, datef FROM " . MAIN_DB_PREFIX . "facture WHERE ref = '" . $db->escape($search_facture) . "'";
 	$result = $db->query($sql);
 
 	$fechaFactura = null;


### PR DESCRIPTION
## Summary

`views/query.facture.php` queries a non-existent `llx_facture.date_creation` column when looking up an invoice by reference. Dolibarr stores the invoice creation timestamp in `datec`.

This selects `datec AS date_creation`, preserving the property name consumed by the existing code.

## Validation

- reproduced on MySQL 8.0.44: `Unknown column 'date_creation' in 'field list'`
- validated the corrected query with MySQL 8 `EXPLAIN` under `ONLY_FULL_GROUP_BY` and `STRICT_TRANS_TABLES`
- PHP syntax checked with PHP 8.3, 8.4 and 8.5
- both bundled test suites pass on PHP 8.3, 8.4 and 8.5