### PR TITLE
FIX validate partially correct AEAT response lines

### DIFF
--- a/lib/functions/functions.cancellation.php
+++ b/lib/functions/functions.cancellation.php
@@ -134,7 +134,7 @@ function createCancellationByType($cancellationType, $invoiceNumber, $invoiceDat
 function processCancellationResponse($response, $facture, $invoiceNumber, $langs)
 {
 	if ($response) {
-		if (isset($response->EstadoEnvio) && in_array($response->EstadoEnvio, ['Correcto', 'ParcialmenteCorrecto'])) {
+		if (isAEATResponseAccepted($response)) {
 			return processCancellationSuccess($response, $facture, $invoiceNumber, $langs);
 		} else {
 			return processCancellationError($response, $facture, $invoiceNumber, $langs);

--- a/lib/functions/functions.response.php
+++ b/lib/functions/functions.response.php
@@ -25,6 +25,42 @@
  */
 
 /**
+ * Checks whether an AEAT response accepted every submitted record.
+ *
+ * A globally partial response is successful only when each response line is
+ * either correct or accepted with non-blocking errors. An incorrect line must
+ * never be persisted as sent.
+ *
+ * @param object $response AEAT response
+ * @return bool True when all submitted records were accepted
+ */
+function isAEATResponseAccepted($response)
+{
+	if (!is_object($response) || empty($response->EstadoEnvio)) {
+		return false;
+	}
+	if ($response->EstadoEnvio === 'Correcto') {
+		return true;
+	}
+	if ($response->EstadoEnvio !== 'ParcialmenteCorrecto' || !isset($response->RespuestaLinea)) {
+		return false;
+	}
+
+	$lines = is_array($response->RespuestaLinea) ? $response->RespuestaLinea : array($response->RespuestaLinea);
+	if (empty($lines)) {
+		return false;
+	}
+	foreach ($lines as $line) {
+		$status = is_object($line) ? ($line->EstadoRegistro ?? '') : '';
+		if (!in_array($status, array('Correcto', 'AceptadoConErrores'), true)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
  * Saves VeriFactu error data using an independent connection
  * to prevent data loss in case of transaction rollback
  *

--- a/lib/functions/functions.submission.php
+++ b/lib/functions/functions.submission.php
@@ -547,7 +547,7 @@ function handleInvoiceCreationOrSubsanation($manager, Facture $facture, $certOpt
 function processInvoiceSendResponse($response, $facture, $manager, $langs, $conf)
 {
 	if ($response) {
-		if (isset($response->EstadoEnvio) && in_array($response->EstadoEnvio, ['Correcto', 'ParcialmenteCorrecto'])) {
+		if (isAEATResponseAccepted($response)) {
 			// SUCCESS
 			$statusMessage = $response->EstadoEnvio === 'Correcto' ? 'successfully' : 'with partial success';
 			dol_syslog("VERIFACTU: Invoice {$facture->ref} sent {$statusMessage}", LOG_INFO);

--- a/tests/PartialResponseTest.php
+++ b/tests/PartialResponseTest.php
@@ -1,0 +1,36 @@
+<?php
+
+require_once __DIR__ . '/../lib/functions/functions.response.php';
+
+function responseWithStatus($globalStatus, $lineStatuses = array())
+{
+	$response = (object) array('EstadoEnvio' => $globalStatus);
+	if (!empty($lineStatuses)) {
+		$lines = array();
+		foreach ($lineStatuses as $status) {
+			$lines[] = (object) array('EstadoRegistro' => $status);
+		}
+		$response->RespuestaLinea = count($lines) === 1 ? $lines[0] : $lines;
+	}
+	return $response;
+}
+
+$cases = array(
+	array('Correcto', array(), true),
+	array('Incorrecto', array('Incorrecto'), false),
+	array('ParcialmenteCorrecto', array('Correcto'), true),
+	array('ParcialmenteCorrecto', array('AceptadoConErrores'), true),
+	array('ParcialmenteCorrecto', array('Incorrecto'), false),
+	array('ParcialmenteCorrecto', array('Correcto', 'Incorrecto'), false),
+	array('ParcialmenteCorrecto', array(), false),
+);
+
+foreach ($cases as $index => $case) {
+	$result = isAEATResponseAccepted(responseWithStatus($case[0], $case[1]));
+	if ($result !== $case[2]) {
+		fwrite(STDERR, 'Failed case ' . ($index + 1) . PHP_EOL);
+		exit(1);
+	}
+}
+
+echo "All partial response tests passed\n";


### PR DESCRIPTION
## Summary

A global `ParcialmenteCorrecto` response can contain rejected (`Incorrecto`) records. The module previously treated every partial response as successful and could persist a rejected invoice or cancellation as sent.

This change:
- accepts `Correcto` global responses
- accepts a partial response only when every line is `Correcto` or `AceptadoConErrores`
- rejects partial responses containing an `Incorrecto`, missing, or unknown line status
- applies the same rule to invoice and cancellation responses

## Validation

- added seven focused response-status cases
- tests pass on PHP 8.3, 8.4 and 8.5
- PHP syntax and `git diff --check` pass