### PR TITLE
FIX respect AEAT submission wait time

### DIFF
--- a/langs/ca_ES/verifactu.lang
+++ b/langs/ca_ES/verifactu.lang
@@ -608,3 +608,4 @@ verifactu_OPERACION_Exenta = Operació Exempta
 verifactu_OPERACION_ExentaTooltip = Tipus d'exempció (E1-E6) quan l'operació està exempta d'IVA/IGIC/IPSI.
 verifactu_INCIDENCIA = Incidència
 verifactu_INCIDENCIATooltip = Indica si hi va haver incidència tècnica (sense electricitat, sense internet, fallada del sistema). Per defecte "N".
+VERIFACTU_AEAT_WAIT_REQUIRED=L'AEAT requereix esperar %s segons abans del següent enviament VeriFactu.

--- a/langs/en_US/verifactu.lang
+++ b/langs/en_US/verifactu.lang
@@ -718,3 +718,4 @@ verifactu_OPERACION_Exenta = Exempt Operation
 verifactu_OPERACION_ExentaTooltip = Exemption type (E1-E6) when operation is VAT/IGIC/IPSI exempt.
 verifactu_INCIDENCIA = Incident
 verifactu_INCIDENCIATooltip = Indicates technical incident (no electricity, no internet, system failure). Defaults to "N".
+VERIFACTU_AEAT_WAIT_REQUIRED=AEAT requires waiting %s seconds before the next VeriFactu submission.

--- a/langs/es_ES/verifactu.lang
+++ b/langs/es_ES/verifactu.lang
@@ -718,3 +718,4 @@ verifactu_OPERACION_Exenta = Operación Exenta
 verifactu_OPERACION_ExentaTooltip = Tipo de exención (E1-E6) cuando la operación está exenta de IVA/IGIC/IPSI.
 verifactu_INCIDENCIA = Incidencia
 verifactu_INCIDENCIATooltip = Indica si hubo incidencia técnica (sin electricidad, sin internet, fallo del sistema). Por defecto "N".
+VERIFACTU_AEAT_WAIT_REQUIRED=La AEAT requiere esperar %s segundos antes del siguiente envío VeriFactu.

--- a/langs/eu_ES/verifactu.lang
+++ b/langs/eu_ES/verifactu.lang
@@ -608,3 +608,4 @@ verifactu_OPERACION_Exenta = Eragiketa Salbuetsia
 verifactu_OPERACION_ExentaTooltip = Salbueste mota (E1-E6) eragiketa BEZ/IGIC/IPSI-tik salbuetsita dagoenean.
 verifactu_INCIDENCIA = Intzidentzia
 verifactu_INCIDENCIATooltip = Intzidentzia teknikoa izan zen adierazten du (argindarik gabe, internetik gabe, sistemaren hutsegitea). Lehenetsita "N".
+VERIFACTU_AEAT_WAIT_REQUIRED=AEATek %s segundo itxarotea eskatzen du hurrengo VeriFactu bidalketa baino lehen.

--- a/langs/gl_ES/verifactu.lang
+++ b/langs/gl_ES/verifactu.lang
@@ -608,3 +608,4 @@ verifactu_OPERACION_Exenta = Operación Exenta
 verifactu_OPERACION_ExentaTooltip = Tipo de exención (E1-E6) cando a operación está exenta de IVE/IGIC/IPSI.
 verifactu_INCIDENCIA = Incidencia
 verifactu_INCIDENCIATooltip = Indica se houbo incidencia técnica (sen electricidade, sen internet, fallo do sistema). Por defecto "N".
+VERIFACTU_AEAT_WAIT_REQUIRED=A AEAT require agardar %s segundos antes do seguinte envío VeriFactu.

--- a/lib/functions/functions.cancellation.php
+++ b/lib/functions/functions.cancellation.php
@@ -40,6 +40,11 @@ use Sietekas\Verifactu\VerifactuInvoiceCancel;
 function handleInvoiceCancellation($manager, Facture $facture, $certOptions, $issuerNif, $issuerName, $cancellationType = 'normal')
 {
 	global $langs;
+	$waitSeconds = getAEATWaitTimeRemaining();
+	if ($waitSeconds > 0) {
+		setEventMessage($langs->trans('VERIFACTU_AEAT_WAIT_REQUIRED', $waitSeconds), 'warnings');
+		return false;
+	}
 
 	// Get invoice data for cancellation
 	$invoiceNumberToCancel = $facture->ref;
@@ -68,6 +73,7 @@ function handleInvoiceCancellation($manager, Facture $facture, $certOptions, $is
 
 	// Send cancellation
 	$response = $manager->sendCancellation($cancellation, $certOptions);
+	registerAEATWaitTime($response);
 
 	// Process response
 	return processCancellationResponse($response, $facture, $invoiceNumberToCancel, $langs);

--- a/lib/functions/functions.response.php
+++ b/lib/functions/functions.response.php
@@ -25,6 +25,38 @@
  */
 
 /**
+ * Stores the next instant at which AEAT allows another submission.
+ *
+ * @param object $response AEAT response
+ * @return int Number of seconds requested by AEAT
+ */
+function registerAEATWaitTime($response)
+{
+	global $conf, $db;
+
+	$waitSeconds = is_object($response) ? (int) ($response->TiempoEsperaEnvio ?? 0) : 0;
+	if ($waitSeconds <= 0) {
+		return 0;
+	}
+	if (!function_exists('dolibarr_set_const')) {
+		require_once DOL_DOCUMENT_ROOT . '/core/lib/admin.lib.php';
+	}
+	$nextSendAt = dol_now() + $waitSeconds;
+	dolibarr_set_const($db, 'VERIFACTU_NEXT_SEND_AT', (string) $nextSendAt, 'chaine', 0, '', $conf->entity);
+	return $waitSeconds;
+}
+
+/**
+ * Returns the remaining AEAT throttling delay for the active entity.
+ *
+ * @return int Remaining seconds
+ */
+function getAEATWaitTimeRemaining()
+{
+	return max(0, getDolGlobalInt('VERIFACTU_NEXT_SEND_AT') - dol_now());
+}
+
+/**
  * Saves VeriFactu error data using an independent connection
  * to prevent data loss in case of transaction rollback
  *

--- a/lib/functions/functions.submission.php
+++ b/lib/functions/functions.submission.php
@@ -53,6 +53,11 @@ function execVERIFACTUCall(Facture $facture, $actionVERIFACTU = 'Alta')
 	$langs->load("verifactu@verifactu");
 
 	dol_syslog("VERIFACTU execVERIFACTUCall START: Invoice id=" . $facture->id . " ref=" . $facture->ref . " action=" . $actionVERIFACTU, LOG_DEBUG);
+	$waitSeconds = getAEATWaitTimeRemaining();
+	if ($waitSeconds > 0) {
+		setEventMessage($langs->trans('VERIFACTU_AEAT_WAIT_REQUIRED', $waitSeconds), 'warnings');
+		return false;
+	}
 
 	// Reload invoice values in case something was modified
 	$res = $facture->fetch($facture->id);
@@ -529,6 +534,8 @@ function handleInvoiceCreationOrSubsanation($manager, Facture $facture, $certOpt
 
 		throw $e;
 	}
+
+	registerAEATWaitTime($response);
 
 	// Process VeriFactu response
 	return processInvoiceSendResponse($response, $facture, $manager, $langs, $conf);


### PR DESCRIPTION
## Summary

The module ignored `TiempoEsperaEnvio` returned by AEAT, allowing immediate subsequent requests that can be rejected for exceeding the required submission rate.

This change stores the next allowed submission timestamp per Dolibarr entity and blocks invoice or cancellation submissions until the delay expires. The wait message is translated in all bundled languages.

## Validation

- verified persistence and retrieval against MySQL 8.0.44
- verified isolation through the entity-scoped Dolibarr constant
- PHP syntax and `git diff --check` pass