### PR TITLE
FIX distinguish RechazoPrevio states

### DIFF
--- a/lib/newfenix/src/Invoice.php
+++ b/lib/newfenix/src/Invoice.php
@@ -222,7 +222,7 @@ class Invoice
      * @param string $date Issue date
      * @param string $taxId Issuer tax ID
      * @param string $name Issuer name
-     * @param bool $priorRejection Whether correcting a rejection
+     * @param bool|null $priorRejection True if previously rejected by AEAT, null if it was never submitted
      * @return self
      */
     public static function createSubsanacion(
@@ -230,12 +230,12 @@ class Invoice
         string $date,
         string $taxId,
         string $name,
-        bool $priorRejection = false
+        ?bool $priorRejection = false
     ): self {
         $instance = new self($serial, $date, $taxId, $name);
         $instance->setAsCorrection(true);
-        if ($priorRejection) {
-            $instance->setAsPreviousRejection(true);
+        if ($priorRejection !== false) {
+            $instance->setAsPreviousRejection($priorRejection);
         }
         return $instance;
     }
@@ -752,14 +752,14 @@ class Invoice
     /**
      * Marks document as correction of prior rejection.
      *
-     * @param bool $isPrior Prior rejection flag
+     * @param bool|null $isPrior True if rejected by AEAT, null if it was never submitted
      * @return self
      */
-    public function setAsPreviousRejection(bool $isPrior = true): self
+    public function setAsPreviousRejection(?bool $isPrior = true): self
     {
-        $this->statusFlags['isPriorRejection'] = $isPrior;
-        if ($isPrior) {
-            $this->payload['RechazoPrevio'] = 'X';
+        $this->statusFlags['isPriorRejection'] = ($isPrior !== false);
+        if ($isPrior !== false) {
+            $this->payload['RechazoPrevio'] = ($isPrior === true ? 'S' : 'X');
             $this->setAsCorrection(true);
         } else {
             unset($this->payload['RechazoPrevio']);

--- a/tests/PriorRejectionTest.php
+++ b/tests/PriorRejectionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+require_once __DIR__ . '/../lib/newfenix/src/Invoice.php';
+
+use OpenAEAT\Billing\Invoice;
+
+function getPriorRejectionValue(Invoice $invoice)
+{
+	$property = new ReflectionProperty($invoice, 'payload');
+	$payload = $property->getValue($invoice);
+	return $payload['RechazoPrevio'] ?? null;
+}
+
+$invoice = new Invoice();
+$invoice->setAsPreviousRejection(true);
+if (getPriorRejectionValue($invoice) !== 'S') {
+	fwrite(STDERR, "Previously rejected records must use S\n");
+	exit(1);
+}
+
+$invoice->setAsPreviousRejection(null);
+if (getPriorRejectionValue($invoice) !== 'X') {
+	fwrite(STDERR, "Records not previously submitted must use X\n");
+	exit(1);
+}
+
+$invoice->setAsPreviousRejection(false);
+if (getPriorRejectionValue($invoice) !== null) {
+	fwrite(STDERR, "False must remove RechazoPrevio\n");
+	exit(1);
+}
+
+echo "All prior rejection tests passed\n";


### PR DESCRIPTION
## Summary

`Invoice::setAsPreviousRejection(true)` previously emitted `RechazoPrevio=X`. AEAT distinguishes records that were submitted and rejected (`S`) from records that were never submitted (`X`).

This change maps:
- `true` to `S`
- `null` to `X`
- `false` to an omitted field

`createSubsanacion()` now accepts the same three-state value.

## Validation

Focused tests pass on PHP 8.3, 8.4 and 8.5; syntax and `git diff --check` pass.