### PR TITLE
FIX require previous record for cancellations

### DIFF
--- a/lib/newfenix/src/Cancellation.php
+++ b/lib/newfenix/src/Cancellation.php
@@ -197,10 +197,8 @@ class Cancellation
     private function verifyChainConfiguration(): void
     {
         $hasPreviousRecord = isset($this->registrationPayload['Encadenamiento']['RegistroAnterior']);
-        $isFirstRecord = isset($this->registrationPayload['Encadenamiento']['PrimerRegistro']);
-
-        if (!$hasPreviousRecord && !$isFirstRecord) {
-            throw new \InvalidArgumentException("Must have chain link to previous record or be marked as first in chain");
+        if (!$hasPreviousRecord) {
+            throw new \InvalidArgumentException("Cancellation records must have a chain link to the previous record");
         }
     }
 
@@ -423,8 +421,7 @@ class Cancellation
      */
     public function setAsFirstInChain(): self
     {
-        $this->registrationPayload['Encadenamiento'] = ['PrimerRegistro' => 'S'];
-        return $this;
+        throw new \LogicException('A cancellation record cannot be the first record in a VeriFactu chain.');
     }
 
     /**

--- a/tests/CancellationChainTest.php
+++ b/tests/CancellationChainTest.php
@@ -1,0 +1,31 @@
+<?php
+
+require_once __DIR__ . '/../lib/newfenix/src/Cancellation.php';
+
+use OpenAEAT\Billing\Cancellation;
+
+$cancellation = new Cancellation('F-1', '01-01-2026', 'A00000000', 'A00000000', 'Test');
+
+try {
+	$cancellation->validate();
+	fwrite(STDERR, "Cancellation without a previous record was accepted\n");
+	exit(1);
+} catch (InvalidArgumentException $e) {
+	// Expected.
+}
+
+try {
+	$cancellation->setAsFirstInChain();
+	fwrite(STDERR, "Cancellation was allowed as first record\n");
+	exit(1);
+} catch (LogicException $e) {
+	// Expected.
+}
+
+$cancellation->setChainLink('A00000000', 'F-0', '31-12-2025', str_repeat('A', 64));
+if (!$cancellation->validate()) {
+	fwrite(STDERR, "Cancellation with a previous record was rejected\n");
+	exit(1);
+}
+
+echo "All cancellation chain tests passed\n";


### PR DESCRIPTION
## Summary

VeriFactu cancellation records must remain linked to the existing billing-record chain. The cancellation model previously allowed `PrimerRegistro=S`.

This change:
- requires `Encadenamiento/RegistroAnterior` during cancellation validation
- rejects attempts to mark a cancellation as the first chain record
- keeps normal chained cancellation behavior unchanged

## Validation

Focused tests cover missing, first-record, and valid previous-record chains on PHP 8.3, 8.4 and 8.5.