### PR TITLE
FIX validate invoices before AEAT submission

### DIFF
--- a/lib/newfenix/src/Invoice.php
+++ b/lib/newfenix/src/Invoice.php
@@ -1070,21 +1070,65 @@ class Invoice
 
         $idFields = ['NumSerieFactura', 'FechaExpedicionFactura', 'IDEmisorFactura'];
         foreach ($idFields as $field) {
-            if (!isset($this->payload['IDFactura'][$field])) {
+            if (!isset($this->payload['IDFactura'][$field]) || $this->payload['IDFactura'][$field] === '') {
                 throw new \InvalidArgumentException("IDFactura incomplete");
             }
         }
 
+		$allowedTypes = [
+			self::TYPE_STANDARD,
+			self::TYPE_SIMPLIFIED,
+			self::TYPE_SUBSTITUTION,
+			self::TYPE_CREDIT_NOTE_LEGAL,
+			self::TYPE_CREDIT_NOTE_80_3,
+			self::TYPE_CREDIT_NOTE_80_4,
+			self::TYPE_CREDIT_NOTE_OTHER,
+			self::TYPE_CREDIT_NOTE_SIMPLIFIED,
+		];
+		if (!in_array($this->payload['TipoFactura'], $allowedTypes, true)) {
+			throw new \InvalidArgumentException('Invalid invoice type');
+		}
+		if (mb_strlen($this->payload['NombreRazonEmisor']) > 120) {
+			throw new \InvalidArgumentException('Issuer name cannot exceed 120 characters');
+		}
+		if (mb_strlen($this->payload['DescripcionOperacion']) > 500) {
+			throw new \InvalidArgumentException('Operation description cannot exceed 500 characters');
+		}
+
         $simplifiedTypes = [self::TYPE_SIMPLIFIED, self::TYPE_CREDIT_NOTE_SIMPLIFIED];
-        if (!in_array($this->payload['TipoFactura'], $simplifiedTypes, true)) {
-            if (empty($this->payload['Destinatarios']['IDDestinatario'] ?? [])) {
-                throw new \InvalidArgumentException("Must have at least one recipient");
-            }
+		$recipientCount = count($this->recipientList);
+		if (in_array($this->payload['TipoFactura'], $simplifiedTypes, true)) {
+			if ($recipientCount > 0) {
+				throw new \InvalidArgumentException('Simplified invoices cannot have recipients');
+			}
+		} elseif ($recipientCount === 0) {
+			throw new \InvalidArgumentException("Must have at least one recipient");
+		}
+		if ($recipientCount > 1000) {
+			throw new \InvalidArgumentException('An invoice cannot have more than 1000 recipients');
         }
 
-        if (empty($this->payload['Desglose']['DetalleDesglose'] ?? [])) {
+		$breakdownCount = count($this->taxEntries);
+		if ($breakdownCount === 0) {
             throw new \InvalidArgumentException("Must have at least one tax breakdown detail");
         }
+		if ($breakdownCount > 12) {
+			throw new \InvalidArgumentException('An invoice cannot have more than 12 tax breakdown details');
+		}
+
+		$chain = $this->payload['Encadenamiento'] ?? array();
+		if (empty($chain['PrimerRegistro']) && empty($chain['RegistroAnterior'])) {
+			throw new \InvalidArgumentException('Invoice must be the first record or link to a previous record');
+		}
+		if (!empty($chain['RegistroAnterior'])) {
+			$previousHash = $chain['RegistroAnterior']['Huella'] ?? '';
+			if (!preg_match('/^[0-9A-F]{64}$/', $previousHash)) {
+				throw new \InvalidArgumentException('Previous fingerprint must be a 64-character uppercase SHA-256 hash');
+			}
+		}
+		if (!empty($this->payload['Huella']) && !preg_match('/^[0-9A-F]{64}$/', $this->payload['Huella'])) {
+			throw new \InvalidArgumentException('Fingerprint must be a 64-character uppercase SHA-256 hash');
+		}
 
         return true;
     }

--- a/tests/InvoiceValidationTest.php
+++ b/tests/InvoiceValidationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+require_once __DIR__ . '/../lib/newfenix/src/Invoice.php';
+
+use OpenAEAT\Billing\Invoice;
+
+function validInvoice($type = Invoice::TYPE_STANDARD)
+{
+	$invoice = new Invoice('F-1', '01-01-2026', 'A00000000', 'Issuer');
+	$invoice->setType($type)->setDescription('Test')->setAsFirstInChain();
+	$invoice->addDesglose(Invoice::QUAL_TAXABLE, 100, null, Invoice::TAX_VAT, Invoice::REGIME_GENERAL, 21, 21);
+	if ($type !== Invoice::TYPE_SIMPLIFIED && $type !== Invoice::TYPE_CREDIT_NOTE_SIMPLIFIED) {
+		$invoice->addRecipient('B00000000', 'Customer');
+	}
+	return $invoice;
+}
+
+function expectInvalid(Invoice $invoice, $label)
+{
+	try {
+		$invoice->validate();
+		fwrite(STDERR, $label . " was accepted\n");
+		exit(1);
+	} catch (InvalidArgumentException $e) {
+		return;
+	}
+}
+
+if (!validInvoice()->validate() || !validInvoice(Invoice::TYPE_SIMPLIFIED)->validate()) {
+	exit(1);
+}
+
+$invoice = validInvoice(Invoice::TYPE_SIMPLIFIED);
+$invoice->addRecipient('B00000000', 'Customer');
+expectInvalid($invoice, 'Simplified invoice with recipient');
+
+$invoice = validInvoice();
+$invoice->setDescription(str_repeat('x', 501));
+expectInvalid($invoice, 'Long description');
+
+$invoice = validInvoice();
+$invoice->setType('XX');
+expectInvalid($invoice, 'Unknown invoice type');
+
+$invoice = new Invoice('F-1', '01-01-2026', 'A00000000', 'Issuer');
+$invoice->setDescription('Test')->addRecipient('B00000000', 'Customer');
+$invoice->addDesglose(Invoice::QUAL_TAXABLE, 100, null, Invoice::TAX_VAT, Invoice::REGIME_GENERAL, 21, 21);
+expectInvalid($invoice, 'Invoice without chain');
+
+echo "All invoice validation tests passed\n";


### PR DESCRIPTION
## Summary

Strengthens local invoice validation before generating or sending an AEAT payload.

Checks include:
- complete and non-empty invoice identification
- supported invoice type
- issuer and description length limits
- recipient requirements, including forbidding recipients on F2/R5
- recipient and breakdown count limits
- mandatory chain configuration
- SHA-256 fingerprint format

## Validation

Focused valid and invalid invoice cases pass on PHP 8.3, 8.4 and 8.5; syntax and `git diff --check` pass.