### PR TITLE
fix: corregir los errores reportados en las issues #30, #31, #32 y #33

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,54 @@ Si el certificado no es reconocido:
 - Comprobar que la contraseña es correcta
 - Asegurarse de que el certificado es de persona jurídica
 
+### Certificados FNMT `.p12` rechazados con OpenSSL 3
+
+Si al subir un `.p12` de la **FNMT** (habitual en autónomos y personas físicas) el
+módulo responde que la contraseña no es correcta aunque sí lo sea, lo más probable
+es que el problema no sea la contraseña sino el cifrado del contenedor PKCS#12.
+
+La FNMT ha protegido históricamente estos ficheros con algoritmos **legacy**
+(`RC2-40-CBC` y `PBE-SHA1-3DES`). **OpenSSL 3** —el que traen Debian 12 y la imagen
+oficial `dolibarr/dolibarr`— desactiva estos algoritmos salvo que se active el
+*legacy provider*, por lo que `openssl_pkcs12_read()` falla con
+`error:0308010C: digital envelope routines::unsupported`.
+
+Desde la versión 1.0.5 el módulo:
+
+- Reintenta automáticamente la extracción con `openssl pkcs12 -legacy`, de modo que
+  en la mayoría de servidores el certificado se acepta sin tocar nada.
+- Distingue en el mensaje de error entre *contraseña incorrecta* y *algoritmo de
+  cifrado legacy no soportado*, en lugar de culpar siempre a la contraseña.
+
+Si aun así falla, el binario `openssl` del servidor no tiene el proveedor legacy
+disponible. Hay dos soluciones:
+
+**Opción A — activar el *legacy provider* en el servidor.** Editar
+`/etc/ssl/openssl.cnf` y dejar la sección de proveedores así:
+
+```ini
+[provider_sect]
+default = default_sect
+legacy = legacy_sect
+
+[default_sect]
+activate = 1
+
+[legacy_sect]
+activate = 1
+```
+
+**Opción B — reexportar el certificado con un algoritmo moderno**, en una máquina
+donde sí se pueda abrir:
+
+```bash
+openssl pkcs12 -legacy -in certificado_fnmt.p12 -nodes -out temporal.pem -password pass:TU_CLAVE
+openssl pkcs12 -export -in temporal.pem -out certificado_moderno.p12 -password pass:TU_CLAVE
+rm temporal.pem
+```
+
+Después subir `certificado_moderno.p12` desde la pestaña **Certificados**.
+
 ### Pantalla en Blanco
 
 Si aparece una pantalla en blanco al ver facturas:
@@ -305,13 +353,106 @@ El módulo calcula correctamente el `ImporteTotal` para VeriFactu excluyendo la 
 
 ## Información del Módulo
 
-- **Versión**: 1.0.4
+- **Versión**: 1.0.5
 - **Autor**: Germán Luis Aracil Boned
 - **Email**: garacilb@gmail.com
 - **Licencia**: GPL-3.0-or-later
 - **Dedicado a**: Mi compañero y amigo Ildefonso González Rodríguez
 
 ## Registro de Cambios
+
+### v1.0.5 (2026-08-22)
+
+#### Correcciones
+
+- **Fatal error en el informe de pagos (issue #31)**: `beforePDFCreation()` daba
+  `Call to undefined method pdf_paiement_fourn::fetch_optionals()` al generar el
+  informe de pagos de facturas de cliente o de proveedor. Ese hook no lo disparan
+  solo los modelos PDF de factura: los modelos de informe (`pdf_paiement`,
+  `pdf_paiement_fourn`) también lo lanzan, pero pasan como `$object` el propio
+  modelo PDF, que no extiende `CommonObject` y no tiene `fetch_optionals()`.
+  Añadido un guard que sale limpiamente cuando el objeto no es un objeto de
+  negocio. De paso, se deja de acceder al extrafield cuando no existe, lo que
+  además eliminaba un warning de PHP 8.
+
+- **TypeError en el QR con PHP 8 (issue #32)**: `QRGenerator::renderQrCode()`
+  declaraba `int $outputType`, pero las constantes `QRCode::OUTPUT_IMAGE_PNG` y
+  `QRCode::OUTPUT_MARKUP_SVG` de `chillerlan/php-qrcode` son *strings*. Con
+  `declare(strict_types=1)`, PHP 8 rechazaba toda llamada y rompía la pestaña
+  VeriFactu y la vista de factura (el QR del PDF no se veía afectado porque usa
+  `TCPDF::write2DBarcode()`). Corregido el tipo del parámetro a `string`.
+
+- **Certificados FNMT `.p12` con cifrado legacy (issue #33)**: los contenedores
+  PKCS#12 protegidos con `RC2-40-CBC` / `PBE-SHA1-3DES` —los habituales de la
+  FNMT— fallaban bajo OpenSSL 3 y el módulo lo notificaba como *"Verifique la
+  contraseña"*, que es engañoso. Ahora la extracción reintenta automáticamente
+  con `openssl pkcs12 -legacy` y el mensaje de error distingue entre contraseña
+  incorrecta, algoritmo legacy no soportado y fallo genérico. Documentado en la
+  sección de resolución de problemas.
+
+- **Identidad del sistema declarada vs. transmitida (issue #30, puntos 1 y 6)**:
+  la declaración responsable declaraba `IdSistemaInformatico` =
+  `VERIFACTU-DOLIBARR-OSS` y nombre `VeriFactu para Dolibarr ERP/CRM`, mientras
+  que a la AEAT se enviaban `DV` y `Dolibarr Verifactu Module`. El Art. 15.2
+  de la Orden HAC/1177/2024 exige que coincidan. Se ha unificado tomando como
+  válidos los valores que admite el esquema oficial: `SuministroInformacion.xsd`
+  define `IdSistemaInformatico` como `sf:TextMax2Type` (máximo 2 caracteres) y
+  `NombreSistemaInformatico` como `sf:TextMax30Type` (máximo 30), por lo que los
+  valores largos que se declaraban serían rechazados por el webservice.
+  `getSystemConfig()` lee ahora la identidad de la propia declaración
+  responsable, de modo que ya no pueden divergir, y aplica los límites del
+  esquema. Además el campo `Version` transmitía `DOL_VERSION` (la versión de
+  Dolibarr) en lugar de la del módulo, que es lo que exige el Art. 15.2.c.
+
+- **Hash de integridad incompleto (issue #30, punto 2)**: la lista
+  `ficheros_verificados` referenciaba `interface_99_...` en vez de
+  `interface_999_...` y `class/verifactu.class.php`, que no existe. Como
+  `calcularHashModuloVerifactu()` ignoraba en silencio los ficheros ausentes, el
+  trigger principal quedaba fuera del cálculo de integridad. Corregida la lista,
+  ampliada con los ficheros críticos de hash, envío y anulación, y ahora la
+  función registra los ficheros no encontrados en
+  `integridad.ficheros_no_encontrados` y en el log en lugar de callarlos.
+
+- **Facturas proforma enviadas a la AEAT como F1 (issue #30, punto 3)**: una
+  proforma no es una factura expedida legalmente y no debe generar registro de
+  facturación (Art. 6 RD 1007/2023). Nueva función
+  `isVerifactuApplicableInvoice()` que las excluye tanto en el trigger de
+  validación como en `execVERIFACTUCall()`, con lo que quedan fuera de todas las
+  vías de envío (validación, pestaña VeriFactu, listado, envío masivo y
+  reintentos). Las proformas siguen validándose con normalidad en Dolibarr.
+
+- **Tipo rectificativo divergente (issue #30, punto 5)**: `billCreate()`
+  almacenaba R2 para abonos y facturas de sustitución, pero el envío transmitía
+  R1. La pestaña VeriFactu mostraba por tanto un tipo que nunca era el enviado.
+  Unificado a R1, que es lo que realmente se transmite.
+
+#### Seguridad
+
+- La contraseña del certificado ya no se interpola en la línea de comandos de
+  `openssl`. Las llamadas usan `proc_open` con argumentos en array y pasan la
+  contraseña por variable de entorno (`-password env:`), lo que elimina la
+  posibilidad de inyección de comandos a través de la contraseña y evita que
+  quede visible en la lista de procesos del servidor.
+
+- `prepareLocalCertificate()` ya no hace `die()` ante un fallo de extracción
+  (tumbaba la petición entera): lanza una excepción que el llamador convierte en
+  el mensaje de error habitual del módulo.
+
+#### Archivos Modificados
+- `class/actions_verifactu.class.php` - Guard en `beforePDFCreation()`
+- `lib/newfenix/src/QRGenerator.php` - Tipo del parámetro `$outputType`
+- `lib/functions/functions.certificates.php` - Reintento `-legacy`, clasificación de errores y llamadas seguras a OpenSSL
+- `admin/managecertificates.php` - Mensajes de error diferenciados
+- `lib/functions/functions.configuration.php` - `getDeclaredSystemIdentity()` y `getSystemConfig()`
+- `lib/functions/functions.compatibility.php` - Nueva función `isVerifactuApplicableInvoice()`
+- `lib/functions/functions.submission.php` - Exclusión de proformas
+- `core/triggers/interface_999_modVerifactu_VerifactuTriggers.class.php` - Exclusión de proformas y tipos rectificativos
+- `conf/declaracion_responsable.conf.php` - Identidad del sistema y lista de integridad
+- `core/modules/modVerifactu.class.php` - Versión del módulo
+- Todos los archivos de idioma (es_ES, en_US, ca_ES, eu_ES, gl_ES)
+
+#### Tests
+- `tests/IssueFixesTest.php` - 51 tests de regresión para los issues #30, #31, #32 y #33
 
 ### v1.0.4 (2026-03-04)
 

--- a/README.md
+++ b/README.md
@@ -309,8 +309,31 @@ Desde la versión 1.0.5 el módulo:
 - Distingue en el mensaje de error entre *contraseña incorrecta* y *algoritmo de
   cifrado legacy no soportado*, en lugar de culpar siempre a la contraseña.
 
-Si aun así falla, el binario `openssl` del servidor no tiene el proveedor legacy
-disponible. Hay dos soluciones:
+### Hosting compartido: `exec()` y `proc_open()` desactivados
+
+En muchos alojamientos compartidos (Loading.es, Hostinger y similares) tanto
+`exec()` como `proc_open()` están en `disable_functions`, por lo que el módulo no
+puede invocar el binario `openssl` del sistema.
+
+Desde la versión 1.0.5 esto ya no impide usar certificados: la extracción intenta
+**primero** las funciones OpenSSL propias de PHP (`openssl_pkcs12_read()`), que no
+necesitan lanzar ningún proceso, y solo recurre al binario externo cuando hace
+falta. En la práctica:
+
+| Certificado | Hosting normal | Hosting compartido sin `proc_open` |
+|---|---|---|
+| Cifrado moderno | funciona | **funciona** |
+| Cifrado legacy (FNMT antiguo) | funciona (vía `-legacy`) | no es posible |
+
+El único caso que no tiene solución desde el módulo es un certificado con cifrado
+legacy en un servidor sin acceso al binario `openssl` ni a `openssl.cnf`: ahí hay
+que reexportar el certificado con un algoritmo moderno (opción B más abajo) desde
+otra máquina.
+
+### Si el certificado legacy sigue fallando
+
+Si el binario `openssl` del servidor no tiene el proveedor legacy disponible, hay
+dos soluciones:
 
 **Opción A — activar el *legacy provider* en el servidor.** Editar
 `/etc/ssl/openssl.cnf` y dejar la sección de proveedores así:
@@ -384,6 +407,17 @@ El módulo calcula correctamente el `ImporteTotal` para VeriFactu excluyendo la 
   `declare(strict_types=1)`, PHP 8 rechazaba toda llamada y rompía la pestaña
   VeriFactu y la vista de factura (el QR del PDF no se veía afectado porque usa
   `TCPDF::write2DBarcode()`). Corregido el tipo del parámetro a `string`.
+
+- **Certificados en hosting compartido (feedback del PR #42)**: en alojamientos
+  donde `exec()` y `proc_open()` están ambos en `disable_functions` el módulo no
+  podía leer el certificado en absoluto, y por tanto no podía comunicarse con la
+  AEAT. La extracción usa ahora **primero** las funciones OpenSSL propias de PHP
+  (`openssl_pkcs12_read()`), que no lanzan ningún proceso, y solo recurre al
+  binario externo cuando hace falta (contenedores legacy). Se ha eliminado
+  también el requisito duro de `proc_open` en la conversión a PEM. Los
+  certificados con cifrado moderno funcionan ya de forma transparente en esos
+  servidores; los legacy siguen necesitando el binario, lo que se comunica con un
+  mensaje explícito.
 
 - **Certificados FNMT `.p12` con cifrado legacy (issue #33)**: los contenedores
   PKCS#12 protegidos con `RC2-40-CBC` / `PBE-SHA1-3DES` —los habituales de la
@@ -464,7 +498,7 @@ Los cambios se han verificado sobre instalaciones reales, no solo en aislamiento
 | Dolibarr 17.0.2 + PHP 8.2 + PostgreSQL 16 | 20/20 comprobaciones en vivo |
 | Dolibarr 17.0.2 + PHP 8.4 + PostgreSQL 16 | 20/20 comprobaciones en vivo |
 | Dolibarr 17.0.2 + PHP 7.4 (mínimo declarado) | 20/20 comprobaciones en vivo |
-| Suite de regresión (PHP 7.4, 8.2 y 8.4) | 59/59 |
+| Suite de regresión (PHP 7.4, 8.2 y 8.4) | 65/65 |
 
 En ambas versiones se activa el módulo, se dispara el hook `beforePDFCreation`
 con el objeto que realmente pasa cada una, se generan los QR y se comprueban las
@@ -476,7 +510,7 @@ modificador no existe, no se añade (añadirlo convertiría una extracción corr
 en un error de "opción desconocida").
 
 #### Tests
-- `tests/IssueFixesTest.php` - 59 tests de regresión para los issues #30, #31, #32 y #33
+- `tests/IssueFixesTest.php` - 65 tests de regresión para los issues #30, #31, #32 y #33
 
 ### v1.0.4 (2026-03-04)
 

--- a/README.md
+++ b/README.md
@@ -461,16 +461,22 @@ Los cambios se han verificado sobre instalaciones reales, no solo en aislamiento
 | Entorno | Resultado |
 |---|---|
 | Dolibarr 22.0.5 + PHP 8.4 + PostgreSQL 16 | 22/22 comprobaciones en vivo |
+| Dolibarr 17.0.2 + PHP 8.2 + PostgreSQL 16 | 20/20 comprobaciones en vivo |
 | Dolibarr 17.0.2 + PHP 8.4 + PostgreSQL 16 | 20/20 comprobaciones en vivo |
 | Dolibarr 17.0.2 + PHP 7.4 (mínimo declarado) | 20/20 comprobaciones en vivo |
-| Suite de regresión (PHP 7.4 y 8.4) | 53/53 |
+| Suite de regresión (PHP 7.4, 8.2 y 8.4) | 59/59 |
 
 En ambas versiones se activa el módulo, se dispara el hook `beforePDFCreation`
 con el objeto que realmente pasa cada una, se generan los QR y se comprueban las
 constantes de tipo de factura contra la clase `Facture` real.
 
+El reintento con `openssl pkcs12 -legacy` está condicionado a que el binario sea
+OpenSSL 3 o superior: en servidores con OpenSSL 1.1.1 o LibreSSL, donde ese
+modificador no existe, no se añade (añadirlo convertiría una extracción correcta
+en un error de "opción desconocida").
+
 #### Tests
-- `tests/IssueFixesTest.php` - 53 tests de regresión para los issues #30, #31, #32 y #33
+- `tests/IssueFixesTest.php` - 59 tests de regresión para los issues #30, #31, #32 y #33
 
 ### v1.0.4 (2026-03-04)
 

--- a/README.md
+++ b/README.md
@@ -369,11 +369,14 @@ El módulo calcula correctamente el `ImporteTotal` para VeriFactu excluyendo la 
   `Call to undefined method pdf_paiement_fourn::fetch_optionals()` al generar el
   informe de pagos de facturas de cliente o de proveedor. Ese hook no lo disparan
   solo los modelos PDF de factura: los modelos de informe (`pdf_paiement`,
-  `pdf_paiement_fourn`) también lo lanzan, pero pasan como `$object` el propio
-  modelo PDF, que no extiende `CommonObject` y no tiene `fetch_optionals()`.
-  Añadido un guard que sale limpiamente cuando el objeto no es un objeto de
-  negocio. De paso, se deja de acceder al extrafield cuando no existe, lo que
-  además eliminaba un warning de PHP 8.
+  `pdf_paiement_fourn`) también lo lanzan, y lo que pasan como `$object` no es una
+  factura. En Dolibarr 22.x pasan el propio modelo PDF, que extiende
+  `CommonDocGenerator` y no tiene `fetch_optionals()`; en Dolibarr 17.x pasan una
+  variable `$object` que nunca se asigna en `write_file()`, es decir `null`. En
+  ambos casos la llamada sin comprobación era un error fatal. Añadido un guard
+  que sale limpiamente cuando el objeto no es un objeto de negocio. De paso, se
+  deja de acceder al extrafield cuando no existe, lo que además eliminaba un
+  warning de PHP 8.
 
 - **TypeError en el QR con PHP 8 (issue #32)**: `QRGenerator::renderQrCode()`
   declaraba `int $outputType`, pero las constantes `QRCode::OUTPUT_IMAGE_PNG` y
@@ -451,8 +454,23 @@ El módulo calcula correctamente el `ImporteTotal` para VeriFactu excluyendo la 
 - `core/modules/modVerifactu.class.php` - Versión del módulo
 - Todos los archivos de idioma (es_ES, en_US, ca_ES, eu_ES, gl_ES)
 
+#### Compatibilidad verificada
+
+Los cambios se han verificado sobre instalaciones reales, no solo en aislamiento:
+
+| Entorno | Resultado |
+|---|---|
+| Dolibarr 22.0.5 + PHP 8.4 + PostgreSQL 16 | 22/22 comprobaciones en vivo |
+| Dolibarr 17.0.2 + PHP 8.4 + PostgreSQL 16 | 20/20 comprobaciones en vivo |
+| Dolibarr 17.0.2 + PHP 7.4 (mínimo declarado) | 20/20 comprobaciones en vivo |
+| Suite de regresión (PHP 7.4 y 8.4) | 53/53 |
+
+En ambas versiones se activa el módulo, se dispara el hook `beforePDFCreation`
+con el objeto que realmente pasa cada una, se generan los QR y se comprueban las
+constantes de tipo de factura contra la clase `Facture` real.
+
 #### Tests
-- `tests/IssueFixesTest.php` - 51 tests de regresión para los issues #30, #31, #32 y #33
+- `tests/IssueFixesTest.php` - 53 tests de regresión para los issues #30, #31, #32 y #33
 
 ### v1.0.4 (2026-03-04)
 

--- a/admin/managecertificates.php
+++ b/admin/managecertificates.php
@@ -146,7 +146,7 @@ if ($action == 'upload_certificate') {
  */
 function extractAndSendPublicKey($certPath, $password)
 {
-	global $conf, $db;
+	global $conf, $db, $langs;
 
 	try {
 		// Read certificate content
@@ -159,6 +159,11 @@ function extractAndSendPublicKey($certPath, $password)
 		$publicCert = '';
 		$privateKey = null;
 		$extractionMethod = '';
+
+		// Why the extraction failed, so the user gets an accurate message instead
+		// of the blanket "check the password" that hid legacy-cipher failures.
+		$legacyCipherDetected = false;
+		$wrongPasswordDetected = false;
 
 		// METHOD 1: Try PHP native functions first
 		$certs = [];
@@ -194,7 +199,15 @@ function extractAndSendPublicKey($certPath, $password)
 			while ($error = openssl_error_string()) {
 				$openssl_errors[] = $error;
 			}
-			dol_syslog("VERIFACTU DEBUG: ❌ openssl_pkcs12_read falló - Errores OpenSSL: " . implode('; ', $openssl_errors), LOG_ERR);
+			$nativeErrorText = implode('; ', $openssl_errors);
+			dol_syslog("VERIFACTU DEBUG: ❌ openssl_pkcs12_read falló - Errores OpenSSL: " . $nativeErrorText, LOG_ERR);
+
+			if (isLegacyCipherOpensslError($nativeErrorText)) {
+				$legacyCipherDetected = true;
+				dol_syslog("VERIFACTU: el contenedor PKCS#12 usa cifrado legacy no soportado por OpenSSL 3; se reintentará con el proveedor legacy", LOG_INFO);
+			} elseif (isWrongPasswordOpensslError($nativeErrorText)) {
+				$wrongPasswordDetected = true;
+			}
 		}
 
 		// METHOD 2: If PHP native extraction of public certificate failed, use external OpenSSL
@@ -209,12 +222,38 @@ function extractAndSendPublicKey($certPath, $password)
 				dol_syslog("VERIFACTU DEBUG: ✅ Certificado público extraído con OpenSSL externo", LOG_DEBUG);
 			} else {
 				dol_syslog("VERIFACTU DEBUG: ❌ También falló OpenSSL externo para certificado público: " . $certResult['message'], LOG_ERR);
+
+				if (!empty($certResult['legacy_cipher'])) {
+					$legacyCipherDetected = true;
+				}
+				if (!empty($certResult['wrong_password'])) {
+					$wrongPasswordDetected = true;
+				}
 			}
 		}
 
 		// Verify we have at least the public certificate
 		if (empty($publicCert)) {
-			return ['success' => false, 'message' => 'Error: No se pudo extraer el certificado público del archivo. Verifique la contraseña.'];
+			// A legacy container that the -legacy retry could not open either means
+			// the server has no legacy provider available at all.
+			if ($legacyCipherDetected && !$wrongPasswordDetected) {
+				return [
+					'success' => false,
+					'message' => $langs->trans('VERIFACTU_CERT_ERROR_LEGACY_ALGORITHM'),
+				];
+			}
+
+			if ($wrongPasswordDetected) {
+				return [
+					'success' => false,
+					'message' => $langs->trans('VERIFACTU_CERT_ERROR_WRONG_PASSWORD'),
+				];
+			}
+
+			return [
+				'success' => false,
+				'message' => $langs->trans('VERIFACTU_CERT_ERROR_EXTRACTION_FAILED'),
+			];
 		}
 
 		// Verify it is a valid certificate

--- a/class/actions_verifactu.class.php
+++ b/class/actions_verifactu.class.php
@@ -1321,9 +1321,13 @@ class ActionsVerifactu
 
 		// The 'beforePDFCreation' hook is not fired only by invoice PDF models.
 		// Report models such as pdf_paiement / pdf_paiement_fourn (Invoices > Reports >
-		// Payment report) fire it too, but pass the PDF model itself as $object.
-		// Those classes do not extend CommonObject and therefore have no
-		// fetch_optionals(), which turned this hook into a fatal error.
+		// Payment report) fire it too, and what they pass as $object is not an invoice:
+		//   - Dolibarr 22.x passes the PDF model itself ($this). That class extends
+		//     CommonDocGenerator, not CommonObject, so it has no fetch_optionals().
+		//   - Dolibarr 17.x passes a $object variable that is never assigned in
+		//     write_file(), i.e. null.
+		// Either way the unguarded call was a fatal error. Verified against 17.0.2
+		// and 22.0.5.
 		if (!is_object($object) || !method_exists($object, 'fetch_optionals')) {
 			return 0;
 		}

--- a/class/actions_verifactu.class.php
+++ b/class/actions_verifactu.class.php
@@ -1319,10 +1319,25 @@ class ActionsVerifactu
 	{
 		global  $langs;
 
+		// The 'beforePDFCreation' hook is not fired only by invoice PDF models.
+		// Report models such as pdf_paiement / pdf_paiement_fourn (Invoices > Reports >
+		// Payment report) fire it too, but pass the PDF model itself as $object.
+		// Those classes do not extend CommonObject and therefore have no
+		// fetch_optionals(), which turned this hook into a fatal error.
+		if (!is_object($object) || !method_exists($object, 'fetch_optionals')) {
+			return 0;
+		}
+
 		$langs->load("verifactu@verifactu");
-		if ($object->fetch_optionals() && $object->array_options['options_verifactu_factura_tipo'] == Sietekas\Verifactu\VerifactuInvoice::TYPE_SIMPLIFIED) {
+
+		if ($object->fetch_optionals() <= 0 || empty($object->array_options['options_verifactu_factura_tipo'])) {
+			return 0;
+		}
+
+		if ($object->array_options['options_verifactu_factura_tipo'] == Sietekas\Verifactu\VerifactuInvoice::TYPE_SIMPLIFIED) {
 			$langs->tab_translate["PdfInvoiceTitle"] = $langs->trans("verifactu_FACTURA_Simplificada"); // Translation ID for "Simplified Invoice"
 		}
+
 		return 0;
 	}
 

--- a/conf/declaracion_responsable.conf.php
+++ b/conf/declaracion_responsable.conf.php
@@ -105,24 +105,43 @@ $declaracionResponsable['sistema'] = array(
     'nombre' => 'VeriFactu para Dolibarr ERP/CRM',
 
     /**
-     * IdSistemaInformatico - Código identificador único
-     * Asignado por el productor para identificar unívocamente el sistema
-     * @required Obligatorio según Art. 15.2.b) Orden HAC/1177/2024
-     * @format Alfanumérico, máximo 30 caracteres
+     * NombreSistemaInformatico - Nombre exacto que se transmite a la AEAT
+     * en el bloque SistemaInformatico de cada registro de facturación.
+     * Debe coincidir con lo declarado y respetar el límite del esquema oficial.
+     * @required Obligatorio según Art. 15.2.a) Orden HAC/1177/2024
+     * @format Alfanumérico, máximo 30 caracteres (sf:TextMax30Type)
      */
-    'id_sistema_informatico' => 'VERIFACTU-DOLIBARR-OSS',
+    'nombre_sistema_informatico' => 'Dolibarr Verifactu Module',
+
+    /**
+     * IdSistemaInformatico - Código identificador único
+     * Asignado por el productor para identificar unívocamente el sistema.
+     *
+     * IMPORTANTE: el esquema oficial de la AEAT (SuministroInformacion.xsd)
+     * define este campo como sf:TextMax2Type, es decir un MÁXIMO DE 2
+     * CARACTERES. Un identificador más largo es rechazado por el webservice,
+     * por lo que el valor declarado debe ser el mismo código corto que se
+     * transmite en cada registro.
+     *
+     * @required Obligatorio según Art. 15.2.b) Orden HAC/1177/2024
+     * @format Alfanumérico, máximo 2 caracteres (sf:TextMax2Type)
+     */
+    'id_sistema_informatico' => 'DV',
 
     /**
      * Versión del sistema informático
-     * Identificador completo de la versión concreta
+     * Identificador completo de la versión concreta.
+     * Debe coincidir con $this->verifactu_version de modVerifactu.class.php,
+     * ya que es el valor que se transmite en el campo Version.
      * @required Obligatorio según Art. 15.2.c) Orden HAC/1177/2024
+     * @format Alfanumérico, máximo 50 caracteres (sf:TextMax50Type)
      */
-    'version' => '1.0.2',
+    'version' => '1.0.5',
 
     /**
      * Fecha de la versión
      */
-    'fecha_version' => '2025-07-16',
+    'fecha_version' => '2026-08-22',
 
     /**
      * Número de instalación/instancia (generado automáticamente)
@@ -321,12 +340,24 @@ $declaracionResponsable['integridad'] = array(
      */
     'ficheros_verificados' => array(
         'core/modules/modVerifactu.class.php',
-        'class/verifactu.class.php',
+        'class/actions_verifactu.class.php',
         'class/verifactu.utils.php',
         'lib/verifactu.lib.php',
         'lib/verifactu-types.array.php',
-        'core/triggers/interface_99_modVerifactu_VerifactuTriggers.class.php',
+        'core/triggers/interface_999_modVerifactu_VerifactuTriggers.class.php',
+        'core/triggers/interface_900_modVerifactu_BillRestrictions.class.php',
+        'lib/functions/functions.hash.php',
+        'lib/functions/functions.submission.php',
+        'lib/functions/functions.cancellation.php',
+        'lib/functions/functions.configuration.php',
     ),
+
+    /**
+     * Ficheros declarados que no se han encontrado en disco
+     * Se rellena en calcularHashModuloVerifactu(). Debe estar siempre vacío:
+     * un fichero ausente queda fuera del hash y por tanto sin verificar.
+     */
+    'ficheros_no_encontrados' => array(),
 );
 
 /**
@@ -464,11 +495,17 @@ function calcularHashModuloVerifactu($basePath = '')
     }
 
     $contenidoTotal = '';
+    $noEncontrados = array();
 
     foreach ($declaracionResponsable['integridad']['ficheros_verificados'] as $fichero) {
         $rutaCompleta = $basePath . '/' . $fichero;
         if (file_exists($rutaCompleta)) {
             $contenidoTotal .= file_get_contents($rutaCompleta);
+        } else {
+            // Un fichero declarado pero ausente quedaría fuera del hash sin dejar
+            // rastro. Se registra para que la ausencia sea visible en la
+            // declaración responsable y en el log del sistema.
+            $noEncontrados[] = $fichero;
         }
     }
 
@@ -477,6 +514,15 @@ function calcularHashModuloVerifactu($basePath = '')
     // Actualizar valores en la configuración
     $declaracionResponsable['integridad']['hash_modulo'] = $hash;
     $declaracionResponsable['integridad']['fecha_calculo'] = date('Y-m-d H:i:s');
+    $declaracionResponsable['integridad']['ficheros_no_encontrados'] = $noEncontrados;
+
+    if (!empty($noEncontrados) && function_exists('dol_syslog')) {
+        dol_syslog(
+            'VERIFACTU: ficheros declarados para el hash de integridad no encontrados: '
+                . implode(', ', $noEncontrados),
+            LOG_WARNING
+        );
+    }
 
     return $hash;
 }

--- a/core/modules/modVerifactu.class.php
+++ b/core/modules/modVerifactu.class.php
@@ -77,9 +77,9 @@ class modVerifactu extends DolibarrModules
 		$this->editor_url = '';
 
 		// Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated' or a version string like 'x.y.z'
-		$this->version = '1.0.3';
-		$this->verifactu_version = '1.0.3';
-		$this->verifactu_version_date = '20/12/2025';
+		$this->version = '1.0.5';
+		$this->verifactu_version = '1.0.5';
+		$this->verifactu_version_date = '22/08/2026';
 		// Url to the file with your last numberversion of this module
 		$this->url_last_version = '';
 

--- a/core/triggers/interface_999_modVerifactu_VerifactuTriggers.class.php
+++ b/core/triggers/interface_999_modVerifactu_VerifactuTriggers.class.php
@@ -161,20 +161,30 @@ class InterfaceVerifactuTriggers extends DolibarrTriggers
 					$object->array_options['options_verifactu_factura_tipo'] = Sietekas\Verifactu\VerifactuInvoice::TYPE_STANDARD;
 					break;
 				case $object::TYPE_REPLACEMENT:
-					// Corrective invoice -> R2 (Art. 80.3 LIVA) - Doli doesn't allow selecting specific type
-					$object->array_options['options_verifactu_factura_tipo'] = Sietekas\Verifactu\VerifactuInvoice::TYPE_CREDIT_NOTE_80_3;
+					// Replacement invoice -> R1 (Corrective, Art. 80.1 and 80.2 LIVA
+					// and errors in law). Kept in sync with functions.submission.php,
+					// which transmits R1 by substitution for this Dolibarr type:
+					// storing R2 here made the VeriFactu tab show a type that was
+					// never the one sent to AEAT.
+					$object->array_options['options_verifactu_factura_tipo'] = Sietekas\Verifactu\VerifactuInvoice::TYPE_CREDIT_NOTE_LEGAL;
 					break;
 				case $object::TYPE_CREDIT_NOTE:
-					// Credit note invoice -> R2 (Corrective for total or partial return Art. 80.3 LIVA)
-					$object->array_options['options_verifactu_factura_tipo'] = Sietekas\Verifactu\VerifactuInvoice::TYPE_CREDIT_NOTE_80_3;
+					// Credit note invoice -> R1 (Corrective, Art. 80.1 and 80.2 LIVA
+					// and errors in law). Kept in sync with functions.submission.php,
+					// which transmits R1 by differences for non-TakePOS credit notes.
+					$object->array_options['options_verifactu_factura_tipo'] = Sietekas\Verifactu\VerifactuInvoice::TYPE_CREDIT_NOTE_LEGAL;
 					break;
 				case $object::TYPE_DEPOSIT:
 					// Deposit invoice -> F1 (Considered normal "Invoice" - advance payment)
 					$object->array_options['options_verifactu_factura_tipo'] = Sietekas\Verifactu\VerifactuInvoice::TYPE_STANDARD;
 					break;
 				case $object::TYPE_PROFORMA:
-					// Proforma invoice -> F1 (Considered normal invoice)
-					$object->array_options['options_verifactu_factura_tipo'] = Sietekas\Verifactu\VerifactuInvoice::TYPE_STANDARD;
+					// Proforma invoice -> no VeriFactu type at all.
+					// A proforma is not a legally issued invoice: it creates no tax
+					// obligation and must not produce a billing record
+					// (Art. 6 RD 1007/2023). It is excluded from the whole
+					// VeriFactu flow by isVerifactuApplicableInvoice().
+					$object->array_options['options_verifactu_factura_tipo'] = '';
 					break;
 			}
 		}
@@ -226,6 +236,15 @@ class InterfaceVerifactuTriggers extends DolibarrTriggers
 		dol_include_once('/verifactu/class/verifactu.utils.php');
 
 		dol_syslog("VERIFACTU TRIGGER billValidate START: Invoice id=" . $object->id . " ref=" . $object->ref . " newref=" . ($object->newref ?? 'NULL') . " status=" . $object->status . " thirdparty_id=" . $object->socid, LOG_DEBUG);
+
+		// Proforma invoices create no tax obligation and are not legally issued
+		// invoices, so they must not generate a VeriFactu billing record
+		// (Art. 6 RD 1007/2023). They still validate normally in Dolibarr, so we
+		// leave before any VeriFactu processing instead of failing the validation.
+		if (!isVerifactuApplicableInvoice($object)) {
+			dol_syslog("VERIFACTU TRIGGER billValidate: Invoice " . $object->ref . " is a proforma, skipped by VeriFactu", LOG_INFO);
+			return 0;
+		}
 
 		// Verify invoice reference is correct
 		$object->fetch_thirdparty();

--- a/langs/ca_ES/verifactu.lang
+++ b/langs/ca_ES/verifactu.lang
@@ -608,3 +608,8 @@ verifactu_OPERACION_Exenta = Operació Exempta
 verifactu_OPERACION_ExentaTooltip = Tipus d'exempció (E1-E6) quan l'operació està exempta d'IVA/IGIC/IPSI.
 verifactu_INCIDENCIA = Incidència
 verifactu_INCIDENCIATooltip = Indica si hi va haver incidència tècnica (sense electricitat, sense internet, fallada del sistema). Per defecte "N".
+
+# Errors de càrrega de certificats
+VERIFACTU_CERT_ERROR_WRONG_PASSWORD = Error: la contrasenya del certificat no és correcta. Comproveu-la i torneu-ho a provar.
+VERIFACTU_CERT_ERROR_LEGACY_ALGORITHM = Error: el certificat està xifrat amb un algorisme antic (RC2-40-CBC / PBE-SHA1-3DES) que OpenSSL 3 desactiva per defecte. Això és habitual en certificats .p12 de la FNMT. La contrasenya pot ser correcta. Solucions: activar el proveïdor "legacy" d'OpenSSL al servidor (secció [provider_sect] de /etc/ssl/openssl.cnf) o tornar a exportar el certificat amb un algorisme modern.
+VERIFACTU_CERT_ERROR_EXTRACTION_FAILED = Error: no s'ha pogut extreure el certificat públic del fitxer. Reviseu el registre d'esdeveniments de Dolibarr per veure el detall de l'error d'OpenSSL.

--- a/langs/en_US/verifactu.lang
+++ b/langs/en_US/verifactu.lang
@@ -718,3 +718,8 @@ verifactu_OPERACION_Exenta = Exempt Operation
 verifactu_OPERACION_ExentaTooltip = Exemption type (E1-E6) when operation is VAT/IGIC/IPSI exempt.
 verifactu_INCIDENCIA = Incident
 verifactu_INCIDENCIATooltip = Indicates technical incident (no electricity, no internet, system failure). Defaults to "N".
+
+# Certificate upload errors
+VERIFACTU_CERT_ERROR_WRONG_PASSWORD = Error: the certificate password is not correct. Please check it and try again.
+VERIFACTU_CERT_ERROR_LEGACY_ALGORITHM = Error: the certificate is encrypted with a legacy algorithm (RC2-40-CBC / PBE-SHA1-3DES) that OpenSSL 3 disables by default. This is common in FNMT .p12 certificates. The password may well be correct. Fixes: enable the OpenSSL "legacy" provider on the server ([provider_sect] section of /etc/ssl/openssl.cnf), or re-export the certificate with a modern algorithm.
+VERIFACTU_CERT_ERROR_EXTRACTION_FAILED = Error: the public certificate could not be extracted from the file. Check the Dolibarr event log for the detailed OpenSSL error.

--- a/langs/es_ES/verifactu.lang
+++ b/langs/es_ES/verifactu.lang
@@ -718,3 +718,8 @@ verifactu_OPERACION_Exenta = Operación Exenta
 verifactu_OPERACION_ExentaTooltip = Tipo de exención (E1-E6) cuando la operación está exenta de IVA/IGIC/IPSI.
 verifactu_INCIDENCIA = Incidencia
 verifactu_INCIDENCIATooltip = Indica si hubo incidencia técnica (sin electricidad, sin internet, fallo del sistema). Por defecto "N".
+
+# Errores de carga de certificados
+VERIFACTU_CERT_ERROR_WRONG_PASSWORD = Error: la contraseña del certificado no es correcta. Compruébela y vuelva a intentarlo.
+VERIFACTU_CERT_ERROR_LEGACY_ALGORITHM = Error: el certificado está cifrado con un algoritmo antiguo (RC2-40-CBC / PBE-SHA1-3DES) que OpenSSL 3 desactiva por defecto. Esto es habitual en certificados .p12 de la FNMT. La contraseña puede ser correcta. Soluciones: activar el proveedor "legacy" de OpenSSL en el servidor (sección [provider_sect] de /etc/ssl/openssl.cnf) o volver a exportar el certificado con un algoritmo moderno.
+VERIFACTU_CERT_ERROR_EXTRACTION_FAILED = Error: no se pudo extraer el certificado público del archivo. Revise el registro de eventos de Dolibarr para ver el detalle del error de OpenSSL.

--- a/langs/eu_ES/verifactu.lang
+++ b/langs/eu_ES/verifactu.lang
@@ -608,3 +608,8 @@ verifactu_OPERACION_Exenta = Eragiketa Salbuetsia
 verifactu_OPERACION_ExentaTooltip = Salbueste mota (E1-E6) eragiketa BEZ/IGIC/IPSI-tik salbuetsita dagoenean.
 verifactu_INCIDENCIA = Intzidentzia
 verifactu_INCIDENCIATooltip = Intzidentzia teknikoa izan zen adierazten du (argindarik gabe, internetik gabe, sistemaren hutsegitea). Lehenetsita "N".
+
+# Ziurtagiriak kargatzeko erroreak
+VERIFACTU_CERT_ERROR_WRONG_PASSWORD = Errorea: ziurtagiriaren pasahitza ez da zuzena. Egiaztatu eta saiatu berriro.
+VERIFACTU_CERT_ERROR_LEGACY_ALGORITHM = Errorea: ziurtagiria algoritmo zahar batekin zifratuta dago (RC2-40-CBC / PBE-SHA1-3DES) eta OpenSSL 3-k lehenetsita desaktibatzen du. Hori ohikoa da FNMTren .p12 ziurtagirietan. Pasahitza zuzena izan daiteke. Konponbideak: OpenSSLren "legacy" hornitzailea aktibatu zerbitzarian (/etc/ssl/openssl.cnf fitxategiko [provider_sect] atala) edo ziurtagiria algoritmo moderno batekin berriro esportatu.
+VERIFACTU_CERT_ERROR_EXTRACTION_FAILED = Errorea: ezin izan da ziurtagiri publikoa fitxategitik atera. Begiratu Dolibarr-en gertaeren erregistroa OpenSSL errorearen xehetasunak ikusteko.

--- a/langs/gl_ES/verifactu.lang
+++ b/langs/gl_ES/verifactu.lang
@@ -608,3 +608,8 @@ verifactu_OPERACION_Exenta = Operación Exenta
 verifactu_OPERACION_ExentaTooltip = Tipo de exención (E1-E6) cando a operación está exenta de IVE/IGIC/IPSI.
 verifactu_INCIDENCIA = Incidencia
 verifactu_INCIDENCIATooltip = Indica se houbo incidencia técnica (sen electricidade, sen internet, fallo do sistema). Por defecto "N".
+
+# Erros de carga de certificados
+VERIFACTU_CERT_ERROR_WRONG_PASSWORD = Erro: o contrasinal do certificado non é correcto. Compróbeo e ténteo de novo.
+VERIFACTU_CERT_ERROR_LEGACY_ALGORITHM = Erro: o certificado está cifrado cun algoritmo antigo (RC2-40-CBC / PBE-SHA1-3DES) que OpenSSL 3 desactiva por defecto. Isto é habitual en certificados .p12 da FNMT. O contrasinal pode ser correcto. Solucións: activar o provedor "legacy" de OpenSSL no servidor (sección [provider_sect] de /etc/ssl/openssl.cnf) ou volver exportar o certificado cun algoritmo moderno.
+VERIFACTU_CERT_ERROR_EXTRACTION_FAILED = Erro: non se puido extraer o certificado público do ficheiro. Revise o rexistro de eventos de Dolibarr para ver o detalle do erro de OpenSSL.

--- a/lib/functions/functions.certificates.php
+++ b/lib/functions/functions.certificates.php
@@ -288,6 +288,131 @@ function runOpensslPkcs12(
 }
 
 /**
+ * Tells whether a PHP function is really callable on this server.
+ *
+ * function_exists() already returns false for anything listed in
+ * disable_functions on current PHP versions, but the ini value is checked too:
+ * some SAPI and hardening setups (common on shared hosting) leave the function
+ * defined while refusing to run it.
+ *
+ * @param string $name Function name
+ * @return bool True when the function can be called
+ */
+function isPhpFunctionAvailable(string $name): bool
+{
+	if (!function_exists($name)) {
+		return false;
+	}
+
+	$disabled = ini_get('disable_functions');
+	if (!is_string($disabled) || $disabled === '') {
+		return true;
+	}
+
+	$disabledList = array_map('trim', explode(',', strtolower($disabled)));
+
+	return !in_array(strtolower($name), $disabledList, true);
+}
+
+/**
+ * Extracts a PKCS#12 container using PHP's own OpenSSL bindings.
+ *
+ * This needs no external process, so it is the only path that works on shared
+ * hosting where exec() and proc_open() are both in disable_functions - a very
+ * common setup among the small Spanish businesses VeriFactu targets.
+ *
+ * It cannot open a container encrypted with a legacy cipher unless the server's
+ * OpenSSL has the legacy provider active, because there is no PHP equivalent of
+ * the "-legacy" switch. That case is reported through the legacy_cipher flag so
+ * the caller can try the external binary instead.
+ *
+ * @param string $certificateFile Path to the .pfx or .p12 file
+ * @param string $certificatePassword Certificate password
+ * @return array{success:bool, public_cert_pem:string, private_key_pem:string, extra_certs:array, message:string, legacy_cipher:bool, wrong_password:bool}
+ */
+function extractPkcs12WithPhp(string $certificateFile, string $certificatePassword): array
+{
+	$failure = array(
+		'success' => false,
+		'public_cert_pem' => '',
+		'private_key_pem' => '',
+		'extra_certs' => array(),
+		'message' => '',
+		'legacy_cipher' => false,
+		'wrong_password' => false,
+	);
+
+	if (!function_exists('openssl_pkcs12_read')) {
+		$failure['message'] = 'The OpenSSL extension is not available in PHP';
+		return $failure;
+	}
+
+	if (!is_readable($certificateFile)) {
+		$failure['message'] = 'Certificate file could not be read: ' . $certificateFile;
+		return $failure;
+	}
+
+	$contents = file_get_contents($certificateFile);
+	if ($contents === false || $contents === '') {
+		$failure['message'] = 'Certificate file is empty: ' . $certificateFile;
+		return $failure;
+	}
+
+	// Drain any error left behind by earlier calls so the diagnosis below
+	// describes this attempt and not a previous one.
+	while (openssl_error_string()) {
+		continue;
+	}
+
+	$bundle = array();
+	if (!openssl_pkcs12_read($contents, $bundle, $certificatePassword)) {
+		$errors = array();
+		while ($error = openssl_error_string()) {
+			$errors[] = $error;
+		}
+		$errorText = implode('; ', $errors);
+
+		$failure['message'] = $errorText !== '' ? $errorText : 'openssl_pkcs12_read() failed without reporting a reason';
+		$failure['legacy_cipher'] = isLegacyCipherOpensslError($errorText);
+		$failure['wrong_password'] = isWrongPasswordOpensslError($errorText);
+
+		return $failure;
+	}
+
+	$publicCert = isset($bundle['cert']) ? (string) $bundle['cert'] : '';
+	$privateKey = '';
+
+	if (isset($bundle['pkey']) && !empty($bundle['pkey'])) {
+		// openssl_pkcs12_read() hands back the key already in PEM form on every
+		// supported PHP version, but normalise it through the key functions so a
+		// resource or handle is exported consistently.
+		if (is_string($bundle['pkey'])) {
+			$privateKey = $bundle['pkey'];
+		} else {
+			$exported = '';
+			if (openssl_pkey_export($bundle['pkey'], $exported)) {
+				$privateKey = $exported;
+			}
+		}
+	}
+
+	if ($publicCert === '') {
+		$failure['message'] = 'The PKCS#12 container has no public certificate';
+		return $failure;
+	}
+
+	return array(
+		'success' => true,
+		'public_cert_pem' => $publicCert,
+		'private_key_pem' => $privateKey,
+		'extra_certs' => isset($bundle['extracerts']) && is_array($bundle['extracerts']) ? $bundle['extracerts'] : array(),
+		'message' => 'Extracted with PHP openssl_pkcs12_read()',
+		'legacy_cipher' => false,
+		'wrong_password' => false,
+	);
+}
+
+/**
  * Builds a human-readable explanation for a failed PKCS#12 extraction.
  *
  * Distinguishes the three cases that used to collapse into the misleading
@@ -341,6 +466,41 @@ function prepareLocalCertificate(
 		return $bundleFile;
 	}
 
+	$passOut = $privateKeyPassword ?? $certificatePassword;
+
+	// PHP-native conversion first: works with no external process, which is the
+	// only option on shared hosting where exec() and proc_open() are disabled.
+	$native = extractPkcs12WithPhp($certificateFile, $certificatePassword);
+	if ($native['success'] && $native['private_key_pem'] !== '') {
+		$privateKeyPem = $native['private_key_pem'];
+
+		if ($encryptKey) {
+			// Re-export the key protected with the requested passphrase.
+			$keyResource = openssl_pkey_get_private($privateKeyPem);
+			$protectedKey = '';
+			if ($keyResource !== false && openssl_pkey_export($keyResource, $protectedKey, $passOut)) {
+				$privateKeyPem = $protectedKey;
+			} else {
+				// Without the passphrase the bundle would silently be weaker
+				// than asked for, so fall through to the external binary.
+				$privateKeyPem = '';
+			}
+		}
+
+		if ($privateKeyPem !== '') {
+			file_put_contents($bundleFile, trim($native['public_cert_pem']) . "\n" . trim($privateKeyPem) . "\n");
+			return $bundleFile;
+		}
+	}
+
+	if (!isPhpFunctionAvailable('proc_open')) {
+		throw new RuntimeException(describeCertificateExtractionFailure(array(
+			'output' => $native['message'] . ' (proc_open is disabled on this server, so the external OpenSSL binary cannot be used either)',
+			'legacy_cipher' => $native['legacy_cipher'],
+			'wrong_password' => $native['wrong_password'],
+		)));
+	}
+
 	$certOut = $outputPath . '_cert.pem';
 	$keyOut = $outputPath . '_key.pem';
 
@@ -360,7 +520,6 @@ function prepareLocalCertificate(
 	}
 
 	// Extract private key (with or without passphrase)
-	$passOut = $privateKeyPassword ?? $certificatePassword;
 	$keyArguments = array('-nocerts');
 	if (!$encryptKey) {
 		$keyArguments[] = '-nodes';
@@ -467,6 +626,18 @@ function extractPrivateKeyWithOpenSSL(
 	string $winOpensslPath = 'C:\laragon\bin\apache\httpd-2.4.54-win64-VS16\bin\openssl.exe'
 ): array {
 
+	// Try PHP's own OpenSSL bindings first: no external process, so this is the
+	// only path available on shared hosting where exec() and proc_open() are
+	// both disabled, and it is cheaper than spawning a binary everywhere else.
+	$native = extractPkcs12WithPhp($certificateFile, $certificatePassword);
+	if ($native['success'] && $native['private_key_pem'] !== '') {
+		return [
+			'success' => true,
+			'private_key_pem' => $native['private_key_pem'],
+			'message' => 'Private key extracted successfully using PHP OpenSSL',
+		];
+	}
+
 	$isWindows = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
 
 	// Verify binary exists
@@ -474,6 +645,18 @@ function extractPrivateKeyWithOpenSSL(
 		return [
 			'success' => false,
 			'message' => 'OpenSSL binary not found at: ' . $winOpensslPath
+		];
+	}
+
+	// Fall back to the external binary, which is the only way to open a legacy
+	// container under OpenSSL 3. If it cannot be launched, report the native
+	// failure instead: it explains the real reason.
+	if (!isPhpFunctionAvailable('proc_open')) {
+		return [
+			'success' => false,
+			'message' => 'proc_open is disabled on this server and PHP could not read the certificate: ' . $native['message'],
+			'legacy_cipher' => $native['legacy_cipher'],
+			'wrong_password' => $native['wrong_password'],
 		];
 	}
 
@@ -575,12 +758,33 @@ function extractPublicCertificateWithOpenSSL(
 	string $winOpensslPath = 'C:\laragon\bin\apache\httpd-2.4.54-win64-VS16\bin\openssl.exe'
 ): array {
 
+	// Try PHP's own OpenSSL bindings first (see extractPrivateKeyWithOpenSSL).
+	$native = extractPkcs12WithPhp($certificateFile, $certificatePassword);
+	if ($native['success']) {
+		return [
+			'success' => true,
+			'public_cert_pem' => $native['public_cert_pem'],
+			'message' => 'Public certificate extracted successfully using PHP OpenSSL',
+		];
+	}
+
 	$isWindows = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
 
 	if ($isWindows && !file_exists($winOpensslPath)) {
 		return [
 			'success' => false,
 			'message' => 'OpenSSL binary not found at: ' . $winOpensslPath
+		];
+	}
+
+	// Fall back to the external binary for legacy containers; when it cannot be
+	// launched, the native failure is the informative one.
+	if (!isPhpFunctionAvailable('proc_open')) {
+		return [
+			'success' => false,
+			'message' => 'proc_open is disabled on this server and PHP could not read the certificate: ' . $native['message'],
+			'legacy_cipher' => $native['legacy_cipher'],
+			'wrong_password' => $native['wrong_password'],
 		];
 	}
 
@@ -913,9 +1117,11 @@ function prepareCertificateLocalForVerifactu()
 		return false;
 	}
 
-	// Verify the functions needed to invoke the OpenSSL binary are enabled
-	if (!function_exists('proc_open')) {
-		$GLOBALS['verifactu_cert_error'] = "The proc_open function is not enabled on your server. Please contact your administrator.";
+	// No hard requirement on proc_open any more: the conversion falls back to
+	// PHP's own OpenSSL bindings, which is what makes the module usable on shared
+	// hosting where exec() and proc_open() are both in disable_functions.
+	if (!function_exists('openssl_pkcs12_read') && !isPhpFunctionAvailable('proc_open')) {
+		$GLOBALS['verifactu_cert_error'] = "Neither the PHP OpenSSL extension nor proc_open is available on your server. Please contact your administrator.";
 		return false;
 	}
 

--- a/lib/functions/functions.certificates.php
+++ b/lib/functions/functions.certificates.php
@@ -153,17 +153,23 @@ function runOpensslCommand(array $arguments, string $password = ''): array
 	);
 
 	// Inherit the current environment and add the password variable.
+	// getenv() is the base because under the usual web SAPI variables_order
+	// ("GPCS", no "E") $_ENV comes back empty, and dropping PATH would leave
+	// proc_open unable to find the openssl binary.
 	$environment = array();
+	if (function_exists('getenv')) {
+		$inherited = getenv();
+		if (is_array($inherited)) {
+			$environment = array_filter($inherited, 'is_string');
+		}
+	}
 	foreach ($_ENV as $key => $value) {
 		if (is_string($value)) {
 			$environment[$key] = $value;
 		}
 	}
-	if (empty($environment) && function_exists('getenv')) {
-		$inherited = getenv();
-		if (is_array($inherited)) {
-			$environment = array_filter($inherited, 'is_string');
-		}
+	if (empty($environment['PATH']) && !empty($_SERVER['PATH']) && is_string($_SERVER['PATH'])) {
+		$environment['PATH'] = $_SERVER['PATH'];
 	}
 	$environment['VERIFACTU_P12_PASS'] = $password;
 

--- a/lib/functions/functions.certificates.php
+++ b/lib/functions/functions.certificates.php
@@ -25,6 +25,288 @@
  */
 
 /**
+ * Returns the OpenSSL binary to invoke on this platform.
+ *
+ * @param string $winOpensslPath Path to OpenSSL binary on Windows
+ * @return string Binary path (unquoted; quoting is handled by the caller)
+ */
+function getOpensslBinary(string $winOpensslPath = 'C:\laragon\bin\apache\httpd-2.4.54-win64-VS16\bin\openssl.exe'): string
+{
+	$isWindows = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
+
+	return $isWindows ? $winOpensslPath : 'openssl';
+}
+
+/**
+ * Tells whether an OpenSSL failure was caused by a legacy PKCS#12 cipher
+ * rather than by a wrong password.
+ *
+ * OpenSSL 3 moved RC2-40-CBC and PBE-SHA1-3DES (the algorithms the FNMT has
+ * historically used to protect .p12 containers for individuals) into the
+ * "legacy" provider, which is not active by default on Debian 12 or in the
+ * official dolibarr/dolibarr image. Reading such a container then fails with
+ * "digital envelope routines::unsupported" (error:0308010C), which is a very
+ * different problem from an incorrect password and deserves a different message.
+ *
+ * @param string $errorText OpenSSL error output (CLI output or openssl_error_string())
+ * @return bool True when the failure points at an unsupported legacy algorithm
+ */
+function isLegacyCipherOpensslError(string $errorText): bool
+{
+	if ($errorText === '') {
+		return false;
+	}
+
+	$needles = array(
+		'0308010c',                     // EVP_R_UNSUPPORTED_ALGORITHM
+		'digital envelope routines',
+		'unsupported algorithm',
+		'rc2-cbc',
+		'rc2-40-cbc',
+		'pbe-sha1-3des',
+		'algorithm (rc2',
+	);
+
+	$haystack = strtolower($errorText);
+	foreach ($needles as $needle) {
+		if (strpos($haystack, $needle) !== false) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Tells whether an OpenSSL failure really was a wrong password.
+ *
+ * @param string $errorText OpenSSL error output (CLI output or openssl_error_string())
+ * @return bool True when the failure points at an invalid password
+ */
+function isWrongPasswordOpensslError(string $errorText): bool
+{
+	if ($errorText === '') {
+		return false;
+	}
+
+	$needles = array(
+		'mac verify error',
+		'mac verify failure',
+		'invalid password',
+		'wrong final block length',
+		'bad decrypt',
+	);
+
+	$haystack = strtolower($errorText);
+	foreach ($needles as $needle) {
+		if (strpos($haystack, $needle) !== false) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Tells whether the OpenSSL binary understands the -legacy switch (OpenSSL 3+).
+ *
+ * @param string $winOpensslPath Path to OpenSSL binary on Windows
+ * @return bool True when -legacy can be used
+ */
+function opensslCliSupportsLegacyFlag(string $winOpensslPath = 'C:\laragon\bin\apache\httpd-2.4.54-win64-VS16\bin\openssl.exe'): bool
+{
+	static $supported = null;
+
+	if ($supported !== null) {
+		return $supported;
+	}
+
+	$result = runOpensslCommand(array(getOpensslBinary($winOpensslPath), 'version'));
+	// "OpenSSL 3.x" and newer ship the legacy provider behind the -legacy switch.
+	$supported = ($result['exit_code'] === 0 && preg_match('/OpenSSL\s+([3-9]|\d{2,})\./', $result['output']) === 1);
+
+	return $supported;
+}
+
+/**
+ * Runs an OpenSSL command without exposing the certificate password.
+ *
+ * Uses proc_open so that arguments are passed as an array (no shell quoting
+ * issues, no command injection through the password) and so that the password
+ * travels in the child process environment instead of the command line, where
+ * it would be visible to any local user through the process list.
+ *
+ * @param array  $arguments Command and arguments, first element is the binary
+ * @param string $password  Password exported as VERIFACTU_P12_PASS (optional)
+ * @return array{exit_code:int, output:string} Exit code and combined output
+ */
+function runOpensslCommand(array $arguments, string $password = ''): array
+{
+	if (!function_exists('proc_open')) {
+		return array('exit_code' => -1, 'output' => 'proc_open is disabled on this server');
+	}
+
+	$descriptors = array(
+		0 => array('pipe', 'r'),
+		1 => array('pipe', 'w'),
+		2 => array('pipe', 'w'),
+	);
+
+	// Inherit the current environment and add the password variable.
+	$environment = array();
+	foreach ($_ENV as $key => $value) {
+		if (is_string($value)) {
+			$environment[$key] = $value;
+		}
+	}
+	if (empty($environment) && function_exists('getenv')) {
+		$inherited = getenv();
+		if (is_array($inherited)) {
+			$environment = array_filter($inherited, 'is_string');
+		}
+	}
+	$environment['VERIFACTU_P12_PASS'] = $password;
+
+	// On Windows proc_open needs a command string; elsewhere the array form
+	// bypasses the shell entirely.
+	$isWindows = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
+	if ($isWindows) {
+		$command = implode(' ', array_map('escapeshellarg', $arguments));
+	} else {
+		$command = $arguments;
+	}
+
+	$process = @proc_open($command, $descriptors, $pipes, null, $environment);
+	if (!is_resource($process)) {
+		return array('exit_code' => -1, 'output' => 'Could not start the OpenSSL process');
+	}
+
+	fclose($pipes[0]);
+	$stdout = stream_get_contents($pipes[1]);
+	fclose($pipes[1]);
+	$stderr = stream_get_contents($pipes[2]);
+	fclose($pipes[2]);
+
+	$exitCode = proc_close($process);
+
+	return array(
+		'exit_code' => $exitCode,
+		'output' => trim($stdout . "\n" . $stderr),
+	);
+}
+
+/**
+ * Runs "openssl pkcs12" retrying with -legacy when the container uses a
+ * legacy cipher that OpenSSL 3 disables by default.
+ *
+ * @param array  $extraArguments  pkcs12 arguments after the subcommand (e.g. -clcerts -nokeys)
+ * @param string $certificateFile Path to the .pfx or .p12 file
+ * @param string $outputFile      Destination file for the extracted PEM
+ * @param string $password        Certificate password
+ * @param string $winOpensslPath  Path to OpenSSL binary on Windows
+ * @return array{success:bool, output:string, used_legacy:bool, legacy_cipher:bool, wrong_password:bool}
+ */
+function runOpensslPkcs12(
+	array $extraArguments,
+	string $certificateFile,
+	string $outputFile,
+	string $password,
+	string $winOpensslPath = 'C:\laragon\bin\apache\httpd-2.4.54-win64-VS16\bin\openssl.exe'
+): array {
+
+	$binary = getOpensslBinary($winOpensslPath);
+
+	$buildCommand = function (bool $withLegacy) use ($binary, $extraArguments, $certificateFile, $outputFile) {
+		$command = array($binary, 'pkcs12');
+		if ($withLegacy) {
+			$command[] = '-legacy';
+		}
+		$command[] = '-in';
+		$command[] = $certificateFile;
+		foreach ($extraArguments as $argument) {
+			$command[] = $argument;
+		}
+		$command[] = '-out';
+		$command[] = $outputFile;
+		$command[] = '-password';
+		$command[] = 'env:VERIFACTU_P12_PASS';
+
+		return $command;
+	};
+
+	// Attempt 1: standard invocation.
+	$result = runOpensslCommand($buildCommand(false), $password);
+	if ($result['exit_code'] === 0) {
+		return array(
+			'success' => true,
+			'output' => $result['output'],
+			'used_legacy' => false,
+			'legacy_cipher' => false,
+			'wrong_password' => false,
+		);
+	}
+
+	$firstOutput = $result['output'];
+
+	// Attempt 2: retry through the legacy provider when the failure looks like a
+	// legacy cipher and the binary supports the switch. This is what makes FNMT
+	// .p12 containers readable again under OpenSSL 3.
+	if (isLegacyCipherOpensslError($firstOutput) && opensslCliSupportsLegacyFlag($winOpensslPath)) {
+		$legacyResult = runOpensslCommand($buildCommand(true), $password);
+		if ($legacyResult['exit_code'] === 0) {
+			return array(
+				'success' => true,
+				'output' => $legacyResult['output'],
+				'used_legacy' => true,
+				'legacy_cipher' => true,
+				'wrong_password' => false,
+			);
+		}
+
+		return array(
+			'success' => false,
+			'output' => $legacyResult['output'] !== '' ? $legacyResult['output'] : $firstOutput,
+			'used_legacy' => true,
+			'legacy_cipher' => true,
+			'wrong_password' => isWrongPasswordOpensslError($legacyResult['output']),
+		);
+	}
+
+	return array(
+		'success' => false,
+		'output' => $firstOutput,
+		'used_legacy' => false,
+		'legacy_cipher' => isLegacyCipherOpensslError($firstOutput),
+		'wrong_password' => isWrongPasswordOpensslError($firstOutput),
+	);
+}
+
+/**
+ * Builds a human-readable explanation for a failed PKCS#12 extraction.
+ *
+ * Distinguishes the three cases that used to collapse into the misleading
+ * "check the password" message: an unsupported legacy cipher, a genuinely wrong
+ * password, and anything else.
+ *
+ * @param array $run Result returned by runOpensslPkcs12()
+ * @return string Explanatory message
+ */
+function describeCertificateExtractionFailure(array $run): string
+{
+	if (!empty($run['legacy_cipher'])) {
+		return 'The certificate uses a legacy encryption algorithm (RC2-40-CBC / PBE-SHA1-3DES) '
+			. 'that OpenSSL 3 disables by default. Enable the OpenSSL legacy provider on the server, '
+			. 'or re-export the certificate with a modern algorithm. OpenSSL output: ' . $run['output'];
+	}
+
+	if (!empty($run['wrong_password'])) {
+		return 'The certificate password is not correct. OpenSSL output: ' . $run['output'];
+	}
+
+	return 'Could not extract the certificate. OpenSSL output: ' . $run['output'];
+}
+
+/**
  * Converts a PFX/P12 certificate to a combined PEM file with certificate and private key,
  * optionally encrypting the key with a passphrase.
  *
@@ -53,30 +335,57 @@ function prepareLocalCertificate(
 		return $bundleFile;
 	}
 
-	$isWindows = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
-	$opensslBin = $isWindows ? "\"$winOpensslPath\"" : 'openssl';
-
 	$certOut = $outputPath . '_cert.pem';
 	$keyOut = $outputPath . '_key.pem';
 
-	// Extract certificate without key
-	$cmdCert = "$opensslBin pkcs12 -in \"$certificateFile\" -clcerts -nokeys -out \"$certOut\" -password pass:$certificatePassword";
-	exec($cmdCert, $outputCert, $codeCert);
+	// Extract certificate without key.
+	// runOpensslPkcs12() retries with -legacy so that FNMT containers protected
+	// with RC2-40-CBC / PBE-SHA1-3DES keep working under OpenSSL 3.
+	$certRun = runOpensslPkcs12(
+		array('-clcerts', '-nokeys'),
+		$certificateFile,
+		$certOut,
+		$certificatePassword,
+		$winOpensslPath
+	);
 
-	if ($codeCert !== 0 || !file_exists($certOut)) {
-		die("Error extracting certificate.");
+	if (!$certRun['success'] || !file_exists($certOut)) {
+		throw new RuntimeException(describeCertificateExtractionFailure($certRun));
 	}
 
 	// Extract private key (with or without passphrase)
 	$passOut = $privateKeyPassword ?? $certificatePassword;
-	$cmdKey = "$opensslBin pkcs12 -in \"$certificateFile\" -nocerts " .
-		($encryptKey ? '' : '-nodes') .
-		" -out \"$keyOut\" -password pass:$certificatePassword" .
-		($encryptKey ? " -passout pass:$passOut" : '');
-	exec($cmdKey, $outputKey, $codeKey);
+	$keyArguments = array('-nocerts');
+	if (!$encryptKey) {
+		$keyArguments[] = '-nodes';
+	}
+	if ($encryptKey) {
+		// -passout accepts the same env: syntax as -password; a second variable
+		// keeps the passphrase off the command line as well.
+		putenv('VERIFACTU_P12_PASSOUT=' . $passOut);
+		$_ENV['VERIFACTU_P12_PASSOUT'] = $passOut;
+		$keyArguments[] = '-passout';
+		$keyArguments[] = 'env:VERIFACTU_P12_PASSOUT';
+	}
 
-	if ($codeKey !== 0 || !file_exists($keyOut)) {
-		die("Error extracting private key.");
+	$keyRun = runOpensslPkcs12(
+		$keyArguments,
+		$certificateFile,
+		$keyOut,
+		$certificatePassword,
+		$winOpensslPath
+	);
+
+	if ($encryptKey) {
+		putenv('VERIFACTU_P12_PASSOUT');
+		unset($_ENV['VERIFACTU_P12_PASSOUT']);
+	}
+
+	if (!$keyRun['success'] || !file_exists($keyOut)) {
+		if (file_exists($certOut)) {
+			unlink($certOut);
+		}
+		throw new RuntimeException(describeCertificateExtractionFailure($keyRun));
 	}
 
 	// Combine into a single .pem
@@ -153,7 +462,6 @@ function extractPrivateKeyWithOpenSSL(
 ): array {
 
 	$isWindows = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
-	$opensslBin = $isWindows ? "\"$winOpensslPath\"" : 'openssl';
 
 	// Verify binary exists
 	if ($isWindows && !file_exists($winOpensslPath)) {
@@ -167,21 +475,31 @@ function extractPrivateKeyWithOpenSSL(
 	$tempKey = tempnam(sys_get_temp_dir(), 'verifactu_key_') . '.pem';
 
 	try {
-		// Command to extract private key without encryption
-		$cmd = "$opensslBin pkcs12 -in \"$certificateFile\" -nocerts -nodes -out \"$tempKey\" -password pass:$certificatePassword 2>&1";
+		// Extract the private key without encryption, retrying through the
+		// legacy provider for FNMT containers that OpenSSL 3 refuses by default.
+		$run = runOpensslPkcs12(
+			array('-nocerts', '-nodes'),
+			$certificateFile,
+			$tempKey,
+			$certificatePassword,
+			$winOpensslPath
+		);
 
-		// Execute command
-		exec($cmd, $output, $returnCode);
-
-		if ($returnCode !== 0) {
+		if (!$run['success']) {
 			if (file_exists($tempKey)) {
 				unlink($tempKey);
 			}
 
 			return [
 				'success' => false,
-				'message' => 'OpenSSL command failed: ' . implode("\n", $output)
+				'message' => 'OpenSSL command failed: ' . $run['output'],
+				'legacy_cipher' => $run['legacy_cipher'],
+				'wrong_password' => $run['wrong_password'],
 			];
+		}
+
+		if ($run['used_legacy'] && function_exists('dol_syslog')) {
+			dol_syslog('VERIFACTU: private key extracted using the OpenSSL legacy provider (-legacy)', LOG_INFO);
 		}
 
 		if (!file_exists($tempKey)) {
@@ -252,7 +570,6 @@ function extractPublicCertificateWithOpenSSL(
 ): array {
 
 	$isWindows = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
-	$opensslBin = $isWindows ? "\"$winOpensslPath\"" : 'openssl';
 
 	if ($isWindows && !file_exists($winOpensslPath)) {
 		return [
@@ -264,19 +581,31 @@ function extractPublicCertificateWithOpenSSL(
 	$tempCert = tempnam(sys_get_temp_dir(), 'verifactu_cert_') . '.pem';
 
 	try {
-		$cmd = "$opensslBin pkcs12 -in \"$certificateFile\" -clcerts -nokeys -out \"$tempCert\" -password pass:$certificatePassword 2>&1";
+		// Extract the public certificate, retrying through the legacy provider
+		// for FNMT containers that OpenSSL 3 refuses by default.
+		$run = runOpensslPkcs12(
+			array('-clcerts', '-nokeys'),
+			$certificateFile,
+			$tempCert,
+			$certificatePassword,
+			$winOpensslPath
+		);
 
-		exec($cmd, $output, $returnCode);
-
-		if ($returnCode !== 0) {
+		if (!$run['success']) {
 			if (file_exists($tempCert)) {
 				unlink($tempCert);
 			}
 
 			return [
 				'success' => false,
-				'message' => 'OpenSSL command failed: ' . implode("\n", $output)
+				'message' => 'OpenSSL command failed: ' . $run['output'],
+				'legacy_cipher' => $run['legacy_cipher'],
+				'wrong_password' => $run['wrong_password'],
 			];
+		}
+
+		if ($run['used_legacy'] && function_exists('dol_syslog')) {
+			dol_syslog('VERIFACTU: public certificate extracted using the OpenSSL legacy provider (-legacy)', LOG_INFO);
 		}
 
 		if (!file_exists($tempCert)) {
@@ -578,9 +907,9 @@ function prepareCertificateLocalForVerifactu()
 		return false;
 	}
 
-	// Verify exec function is enabled
-	if (!function_exists('exec')) {
-		$GLOBALS['verifactu_cert_error'] = "The exec function is not enabled on your server. Please contact your administrator.";
+	// Verify the functions needed to invoke the OpenSSL binary are enabled
+	if (!function_exists('proc_open')) {
+		$GLOBALS['verifactu_cert_error'] = "The proc_open function is not enabled on your server. Please contact your administrator.";
 		return false;
 	}
 
@@ -592,13 +921,21 @@ function prepareCertificateLocalForVerifactu()
 		// If not .pem, convert to .pem
 		$privateKey = ($dolibarr_main_instance_unique_id ? $dolibarr_main_instance_unique_id : $certPassphrase);
 		$outputPath = $conf->verifactu->multidir_output[$conf->entity] . "/certificates/";
-		$localCert = prepareLocalCertificate(
-			$certPath,
-			$outputPath,
-			$certPassphrase,
-			true,               // Encrypt private key
-			$privateKey
-		);
+		try {
+			$localCert = prepareLocalCertificate(
+				$certPath,
+				$outputPath,
+				$certPassphrase,
+				true,               // Encrypt private key
+				$privateKey
+			);
+		} catch (Exception $e) {
+			// prepareLocalCertificate() used to die() here, taking the whole
+			// request down. Report the reason instead so the caller can show it.
+			dol_syslog("VERIFACTU: Certificate conversion failed: " . $e->getMessage(), LOG_ERR);
+			$GLOBALS['verifactu_cert_error'] = $e->getMessage();
+			return false;
+		}
 
 		// Get only the .pem filename
 		$basename = basename($localCert);

--- a/lib/functions/functions.compatibility.php
+++ b/lib/functions/functions.compatibility.php
@@ -81,3 +81,34 @@ function getVerifactuImporteTotal($invoice)
 	// Adding abs() reverses the deduction, yielding: base + IVA + surcharge.
 	return $totalTtc + abs($localtax2);
 }
+
+/**
+ * Tells whether an invoice must generate a VeriFactu billing record.
+ *
+ * Proforma invoices are not legally issued invoices: they are a quotation-like
+ * document that creates no tax obligation, so under Art. 6 RD 1007/2023 they
+ * must not produce a billing record nor be transmitted to AEAT. Dolibarr maps
+ * them to Facture::TYPE_PROFORMA (2).
+ *
+ * Every other invoice type (standard, situation, replacement, credit note and
+ * deposit) is in scope for VeriFactu.
+ *
+ * @param object $invoice Invoice object (Facture)
+ * @return bool True when the invoice must be sent to VeriFactu
+ */
+function isVerifactuApplicableInvoice($invoice)
+{
+	if (!is_object($invoice)) {
+		return false;
+	}
+
+	// Facture::TYPE_PROFORMA is 2. The literal is used as a fallback because this
+	// helper is also reached from contexts where the class may not be loaded.
+	$proformaType = defined('Facture::TYPE_PROFORMA') ? Facture::TYPE_PROFORMA : 2;
+
+	if (isset($invoice->type) && (int) $invoice->type === (int) $proformaType) {
+		return false;
+	}
+
+	return true;
+}

--- a/lib/functions/functions.compatibility.php
+++ b/lib/functions/functions.compatibility.php
@@ -87,11 +87,14 @@ function getVerifactuImporteTotal($invoice)
  *
  * Proforma invoices are not legally issued invoices: they are a quotation-like
  * document that creates no tax obligation, so under Art. 6 RD 1007/2023 they
- * must not produce a billing record nor be transmitted to AEAT. Dolibarr maps
- * them to Facture::TYPE_PROFORMA (2).
+ * must not produce a billing record nor be transmitted to AEAT.
  *
- * Every other invoice type (standard, situation, replacement, credit note and
- * deposit) is in scope for VeriFactu.
+ * Every other invoice type (standard, replacement, credit note, deposit and
+ * situation) is in scope for VeriFactu.
+ *
+ * Dolibarr invoice types (Facture / CommonInvoice, verified against 22.0.5):
+ *   0 TYPE_STANDARD, 1 TYPE_REPLACEMENT, 2 TYPE_CREDIT_NOTE,
+ *   3 TYPE_DEPOSIT,  4 TYPE_PROFORMA,    5 TYPE_SITUATION
  *
  * @param object $invoice Invoice object (Facture)
  * @return bool True when the invoice must be sent to VeriFactu
@@ -102,13 +105,25 @@ function isVerifactuApplicableInvoice($invoice)
 		return false;
 	}
 
-	// Facture::TYPE_PROFORMA is 2. The literal is used as a fallback because this
-	// helper is also reached from contexts where the class may not be loaded.
-	$proformaType = defined('Facture::TYPE_PROFORMA') ? Facture::TYPE_PROFORMA : 2;
-
-	if (isset($invoice->type) && (int) $invoice->type === (int) $proformaType) {
-		return false;
+	if (!isset($invoice->type)) {
+		// Without a type there is nothing to exclude on; treat it as in scope so
+		// that a real invoice is never dropped silently.
+		return true;
 	}
 
-	return true;
+	// Read the constant from the object's own class when possible, so subclasses
+	// and any future renumbering stay correct. The literal 4 is only a last
+	// resort: it must never be confused with TYPE_CREDIT_NOTE (2), which is very
+	// much in scope for VeriFactu.
+	if (defined(get_class($invoice) . '::TYPE_PROFORMA')) {
+		$proformaType = constant(get_class($invoice) . '::TYPE_PROFORMA');
+	} elseif (defined('Facture::TYPE_PROFORMA')) {
+		$proformaType = Facture::TYPE_PROFORMA;
+	} elseif (defined('CommonInvoice::TYPE_PROFORMA')) {
+		$proformaType = CommonInvoice::TYPE_PROFORMA;
+	} else {
+		$proformaType = 4;
+	}
+
+	return (int) $invoice->type !== (int) $proformaType;
 }

--- a/lib/functions/functions.configuration.php
+++ b/lib/functions/functions.configuration.php
@@ -110,6 +110,64 @@ function calculateVerifactuIntegrityChecksums($moduleDirectory)
 }
 
 /**
+ * Gets the identity of this billing system as declared in the responsible declaration
+ *
+ * Art. 15.2 of Orden HAC/1177/2024 requires the software identity declared in the
+ * "declaracion responsable" to be exactly the one transmitted to AEAT in every
+ * billing record. Reading both from the same source removes any chance of drift.
+ *
+ * The values must fit the official AEAT schema (SuministroInformacion.xsd,
+ * SistemaInformatico block):
+ *   - NombreSistemaInformatico : sf:TextMax30Type  (max 30 chars)
+ *   - IdSistemaInformatico     : sf:TextMax2Type   (max  2 chars)
+ *   - Version                  : sf:TextMax50Type  (max 50 chars)
+ *
+ * @return array{name: string, id: string, version: string} Declared system identity
+ */
+function getDeclaredSystemIdentity()
+{
+	// Defaults kept in sync with conf/declaracion_responsable.conf.php so the
+	// function stays usable even if the declaration file cannot be loaded.
+	$identity = [
+		'name' => 'Dolibarr Verifactu Module',
+		'id' => 'DV',
+		'version' => '1.0.5',
+	];
+
+	// Bind the global before including: the declaration file assigns
+	// $declaracionResponsable at file scope, which inside a function would
+	// otherwise land in the local scope and be lost.
+	global $declaracionResponsable;
+
+	$declarationFile = dirname(__DIR__, 2) . '/conf/declaracion_responsable.conf.php';
+	if (is_readable($declarationFile)) {
+		require_once $declarationFile;
+
+		if (!empty($declaracionResponsable['sistema'])) {
+			$system = $declaracionResponsable['sistema'];
+
+			if (!empty($system['nombre_sistema_informatico'])) {
+				$identity['name'] = $system['nombre_sistema_informatico'];
+			}
+			if (!empty($system['id_sistema_informatico'])) {
+				$identity['id'] = $system['id_sistema_informatico'];
+			}
+			if (!empty($system['version'])) {
+				$identity['version'] = $system['version'];
+			}
+		}
+	}
+
+	// Enforce the AEAT schema limits: an oversized value is rejected by the
+	// webservice, so truncate rather than let the submission fail.
+	$identity['name'] = substr($identity['name'], 0, 30);
+	$identity['id'] = substr($identity['id'], 0, 2);
+	$identity['version'] = substr($identity['version'], 0, 50);
+
+	return $identity;
+}
+
+/**
  * Gets the billing system configuration for AEAT
  *
  * @return array System configuration array
@@ -122,13 +180,17 @@ function getSystemConfig()
 	$issuerNif = $conf->global->VERIFACTU_HOLDER_NIF ?? '';
 	$installationNumber = $dolibarr_main_instance_unique_id . '_' . $conf->entity;
 
+	$identity = getDeclaredSystemIdentity();
+
 	return [
 		'NombreRazon' => $issuerName,
 		'NIF' => $issuerNif,
-		'NombreSistemaInformatico' => 'Dolibarr Verifactu Module',
-		'IdSistemaInformatico' => 'DV',
-		'Version' => (defined('DOL_VERSION') ? DOL_VERSION : '1.0.0'),
-		'NumeroInstalacion' => $installationNumber,
+		'NombreSistemaInformatico' => $identity['name'],
+		'IdSistemaInformatico' => $identity['id'],
+		// The module version, not DOL_VERSION: Art. 15.2.c) refers to the version
+		// of the billing system being declared, which is this module.
+		'Version' => $identity['version'],
+		'NumeroInstalacion' => substr($installationNumber, 0, 100),
 		'TipoUsoPosibleSoloVerifactu' => 'S',
 		'TipoUsoPosibleMultiOT' => 'N',
 		'IndicadorMultiplesOT' => 'N',

--- a/lib/functions/functions.submission.php
+++ b/lib/functions/functions.submission.php
@@ -64,6 +64,14 @@ function execVERIFACTUCall(Facture $facture, $actionVERIFACTU = 'Alta')
 
 	dol_syslog("VERIFACTU execVERIFACTUCall: After fetch - ref=" . $facture->ref . " status=" . $facture->status, LOG_DEBUG);
 
+	// Proforma invoices are not legally issued invoices and must never reach AEAT
+	// (Art. 6 RD 1007/2023). Guarding here covers every entry point: validation
+	// trigger, VeriFactu tab, invoice list, mass send and pending-invoice retries.
+	if (!isVerifactuApplicableInvoice($facture)) {
+		dol_syslog("VERIFACTU execVERIFACTUCall: Invoice " . $facture->ref . " is a proforma, skipping VeriFactu submission", LOG_INFO);
+		return false;
+	}
+
 	// Verify actionVERIFACTU is valid
 	if (!in_array($actionVERIFACTU, array('Alta', 'Mod', 'Baja'))) {
 		setEventMessage($langs->trans('INVALID_VERIFACTU_ACTION', $actionVERIFACTU), 'errors');

--- a/lib/newfenix/src/QRGenerator.php
+++ b/lib/newfenix/src/QRGenerator.php
@@ -633,13 +633,18 @@ class QRGenerator
     /**
      * Renders QR code using chillerlan/php-qrcode library.
      *
+     * The output type is declared as string because chillerlan/php-qrcode
+     * exposes QRCode::OUTPUT_* as string constants (QROutputInterface::MARKUP_SVG
+     * = 'svg', QROutputInterface::GDIMAGE_PNG = 'png'). Declaring it as int made
+     * every call fail with a TypeError under declare(strict_types=1).
+     *
      * @param string $content Data to encode
      * @param int $pixels Output size
-     * @param int $outputType QRCode output type constant
+     * @param string $outputType QRCode output type constant (QRCode::OUTPUT_*)
      * @return string Rendered output (binary or markup)
      * @throws \RuntimeException On failure
      */
-    private function renderQrCode(string $content, int $pixels, int $outputType): string
+    private function renderQrCode(string $content, int $pixels, string $outputType): string
     {
         try {
             $scale = max(1, (int) ($pixels / 25));

--- a/tests/IssueFixesTest.php
+++ b/tests/IssueFixesTest.php
@@ -1,0 +1,517 @@
+<?php
+
+/**
+ * Regression tests for reported issues
+ *
+ * Covers:
+ *  - Issue #31: fatal error in beforePDFCreation() when the hook is fired by a
+ *               payment report model (pdf_paiement / pdf_paiement_fourn).
+ *  - Issue #32: TypeError in QRGenerator::renderQrCode() under PHP 8 because the
+ *               chillerlan/php-qrcode output constants are strings, not ints.
+ *  - Issue #30 (2): files listed for the integrity hash must actually exist.
+ *  - Issue #30 (1/6): the system identity declared in the responsible declaration
+ *               must match what is transmitted to AEAT and respect the XSD limits.
+ *
+ * Run with: php tests/IssueFixesTest.php
+ */
+
+error_reporting(E_ALL);
+
+$passed = 0;
+$failed = 0;
+$total = 0;
+
+function assert_test(bool $condition, string $message, &$passed, &$failed, &$total): void
+{
+    $total++;
+    if ($condition) {
+        $passed++;
+        echo "  PASS: $message\n";
+    } else {
+        $failed++;
+        echo "  FAIL: $message\n";
+    }
+}
+
+$moduleRoot = dirname(__DIR__);
+
+echo "=== Reported Issues Regression Tests ===\n\n";
+
+// ---------------------------------------------------------------------------
+// Issue #32 - QR rendering must not throw a TypeError on PHP 8
+// ---------------------------------------------------------------------------
+echo "Issue #32: QRGenerator output type under strict_types\n";
+
+require_once $moduleRoot . '/lib/newfenix/vendor/autoload.php';
+require_once $moduleRoot . '/lib/newfenix/src/QRGenerator.php';
+
+use OpenAEAT\Billing\QRGenerator;
+
+$qrUrl = QRGenerator::generateVerifiableUrl('B12345678', 'FA2026-0001', '22-08-2026', 121.00, true);
+assert_test(strpos($qrUrl, 'nif=B12345678') !== false, 'generateVerifiableUrl() builds the AEAT URL', $passed, $failed, $total);
+
+$reflection = new ReflectionMethod(QRGenerator::class, 'renderQrCode');
+$outputTypeParam = $reflection->getParameters()[2];
+assert_test(
+    (string) $outputTypeParam->getType() === 'string',
+    'renderQrCode() declares $outputType as string (matches QRCode::OUTPUT_* constants)',
+    $passed,
+    $failed,
+    $total
+);
+
+if (extension_loaded('gd')) {
+    $png = null;
+    $error = '';
+    try {
+        $png = (new QRGenerator())->renderPng($qrUrl, 300);
+    } catch (\Throwable $e) {
+        $error = get_class($e) . ': ' . $e->getMessage();
+    }
+    assert_test($error === '', 'renderPng() does not throw' . ($error ? " ($error)" : ''), $passed, $failed, $total);
+    assert_test(is_string($png) && substr($png, 0, 4) === "\x89PNG", 'renderPng() returns PNG binary data', $passed, $failed, $total);
+
+    $base64 = QRGenerator::generateBase64QR($qrUrl, 300, 0);
+    assert_test(strpos($base64, 'data:image/png;base64,') === 0, 'generateBase64QR() returns a PNG data URI', $passed, $failed, $total);
+
+    $svg = (new QRGenerator())->renderSvg($qrUrl, 300);
+    assert_test(strpos($svg, '<svg') !== false, 'renderSvg() returns SVG markup', $passed, $failed, $total);
+} else {
+    echo "  SKIP: GD extension not available, image rendering not exercised\n";
+}
+
+echo "\n";
+
+// ---------------------------------------------------------------------------
+// Issue #31 - beforePDFCreation() must survive non-CommonObject arguments
+// ---------------------------------------------------------------------------
+echo "Issue #31: beforePDFCreation() guard for payment report models\n";
+
+if (!function_exists('dol_include_once')) {
+    /**
+     * Minimal stand-in so the hook class can be loaded without a Dolibarr runtime.
+     *
+     * @param string $relativePath Path relative to the custom directory
+     * @return void
+     */
+    function dol_include_once($relativePath)
+    {
+        // Nothing to load in the test harness.
+    }
+}
+
+/**
+ * Stand-in for Dolibarr's Translate, only what the hook touches.
+ */
+class VerifactuTestTranslate
+{
+    /** @var array<string,string> Overridden translations */
+    public $tab_translate = array();
+
+    /**
+     * @param string $key Language key
+     * @return void
+     */
+    public function load($key)
+    {
+    }
+
+    /**
+     * @param string $key Language key
+     * @return string
+     */
+    public function trans($key)
+    {
+        return $key;
+    }
+}
+
+/**
+ * Stand-in for pdf_paiement_fourn: a PDF report model, not a CommonObject.
+ * It deliberately has no fetch_optionals() method - that is the crash from #31.
+ */
+class VerifactuTestPdfPaiementFourn
+{
+    /** @var string Model type */
+    public $type = 'pdf';
+}
+
+/**
+ * Stand-in for a customer invoice carrying VeriFactu extrafields.
+ */
+class VerifactuTestFacture
+{
+    /** @var array<string,mixed> Extrafield values */
+    public $array_options = array();
+
+    /** @var int Value returned by fetch_optionals() */
+    public $fetchOptionalsResult = 1;
+
+    /**
+     * @return int Result of the extrafield load
+     */
+    public function fetch_optionals()
+    {
+        return $this->fetchOptionalsResult;
+    }
+}
+
+if (!class_exists('Sietekas\Verifactu\VerifactuInvoice')) {
+    eval('namespace Sietekas\Verifactu; class VerifactuInvoice { const TYPE_SIMPLIFIED = "F2"; }');
+}
+
+require_once $moduleRoot . '/class/actions_verifactu.class.php';
+
+$hook = new ActionsVerifactu(null);
+$action = '';
+
+// 1. The exact crash from the report: pdf_paiement_fourn passed as $object.
+$GLOBALS['langs'] = new VerifactuTestTranslate();
+$reportModel = new VerifactuTestPdfPaiementFourn();
+$crash = '';
+$result = null;
+try {
+    $result = $hook->beforePDFCreation(array(), $reportModel, $action);
+} catch (\Throwable $e) {
+    $crash = get_class($e) . ': ' . $e->getMessage();
+}
+assert_test($crash === '', 'payment report model does not raise an error' . ($crash ? " ($crash)" : ''), $passed, $failed, $total);
+assert_test($result === 0, 'payment report model returns 0 (hook continues normally)', $passed, $failed, $total);
+
+// 2. A plain array / null must not crash either.
+$crash = '';
+try {
+    $nothing = null;
+    $hook->beforePDFCreation(array(), $nothing, $action);
+} catch (\Throwable $e) {
+    $crash = get_class($e) . ': ' . $e->getMessage();
+}
+assert_test($crash === '', 'null object does not raise an error' . ($crash ? " ($crash)" : ''), $passed, $failed, $total);
+
+// 3. Simplified invoice still gets its PDF title overridden.
+$GLOBALS['langs'] = new VerifactuTestTranslate();
+$simplified = new VerifactuTestFacture();
+$simplified->array_options['options_verifactu_factura_tipo'] = 'F2';
+$hook->beforePDFCreation(array(), $simplified, $action);
+assert_test(
+    isset($GLOBALS['langs']->tab_translate['PdfInvoiceTitle']),
+    'simplified invoice still overrides the PDF title',
+    $passed,
+    $failed,
+    $total
+);
+
+// 4. A standard invoice leaves the title untouched.
+$GLOBALS['langs'] = new VerifactuTestTranslate();
+$standard = new VerifactuTestFacture();
+$standard->array_options['options_verifactu_factura_tipo'] = 'F1';
+$hook->beforePDFCreation(array(), $standard, $action);
+assert_test(
+    !isset($GLOBALS['langs']->tab_translate['PdfInvoiceTitle']),
+    'standard invoice leaves the PDF title untouched',
+    $passed,
+    $failed,
+    $total
+);
+
+// 5. An invoice with no VeriFactu extrafield at all must not warn.
+$GLOBALS['langs'] = new VerifactuTestTranslate();
+$bare = new VerifactuTestFacture();
+$warning = '';
+set_error_handler(function ($no, $str) use (&$warning) {
+    $warning = $str;
+    return true;
+});
+$hook->beforePDFCreation(array(), $bare, $action);
+restore_error_handler();
+assert_test($warning === '', 'invoice without the extrafield raises no PHP warning' . ($warning ? " ($warning)" : ''), $passed, $failed, $total);
+
+echo "\n";
+
+// ---------------------------------------------------------------------------
+// Issue #30 (point 2) - every file in the integrity hash must exist
+// ---------------------------------------------------------------------------
+echo "Issue #30 (2): integrity hash file list\n";
+
+$GLOBALS['conf'] = (object) array('global' => (object) array(), 'entity' => 1);
+require_once $moduleRoot . '/conf/declaracion_responsable.conf.php';
+
+$verifiedFiles = $declaracionResponsable['integridad']['ficheros_verificados'];
+$missing = array();
+foreach ($verifiedFiles as $relative) {
+    if (!file_exists($moduleRoot . '/' . $relative)) {
+        $missing[] = $relative;
+    }
+}
+assert_test(empty($missing), 'every verified file exists' . ($missing ? ' (missing: ' . implode(', ', $missing) . ')' : ''), $passed, $failed, $total);
+assert_test(
+    in_array('core/triggers/interface_999_modVerifactu_VerifactuTriggers.class.php', $verifiedFiles, true),
+    'the main trigger is included in the integrity hash',
+    $passed,
+    $failed,
+    $total
+);
+
+$hashInfo = calcularHashModuloVerifactu($moduleRoot);
+assert_test(strlen($hashInfo) === 64, 'calcularHashModuloVerifactu() returns a SHA-256 digest', $passed, $failed, $total);
+assert_test(
+    empty($declaracionResponsable['integridad']['ficheros_no_encontrados']),
+    'no verified file is silently skipped',
+    $passed,
+    $failed,
+    $total
+);
+
+echo "\n";
+
+// ---------------------------------------------------------------------------
+// Issue #30 (points 1 and 6) - declared identity == transmitted identity
+// ---------------------------------------------------------------------------
+echo "Issue #30 (1/6): system identity declared vs transmitted\n";
+
+$GLOBALS['dolibarr_main_instance_unique_id'] = 'testinstance';
+require_once $moduleRoot . '/lib/functions/functions.configuration.php';
+
+$systemConfig = getSystemConfig();
+
+assert_test(
+    $systemConfig['IdSistemaInformatico'] === $declaracionResponsable['sistema']['id_sistema_informatico'],
+    'IdSistemaInformatico transmitted matches the one declared',
+    $passed,
+    $failed,
+    $total
+);
+assert_test(
+    $systemConfig['NombreSistemaInformatico'] === $declaracionResponsable['sistema']['nombre_sistema_informatico'],
+    'NombreSistemaInformatico transmitted matches the one declared',
+    $passed,
+    $failed,
+    $total
+);
+assert_test(
+    $systemConfig['Version'] === $declaracionResponsable['sistema']['version'],
+    'Version transmitted matches the one declared',
+    $passed,
+    $failed,
+    $total
+);
+
+// AEAT SuministroInformacion.xsd limits (SistemaInformatico block).
+assert_test(
+    strlen($systemConfig['IdSistemaInformatico']) >= 1 && strlen($systemConfig['IdSistemaInformatico']) <= 2,
+    'IdSistemaInformatico fits TextMax2Type (AEAT XSD)',
+    $passed,
+    $failed,
+    $total
+);
+assert_test(
+    strlen($systemConfig['NombreSistemaInformatico']) <= 30,
+    'NombreSistemaInformatico fits TextMax30Type (AEAT XSD)',
+    $passed,
+    $failed,
+    $total
+);
+assert_test(strlen($systemConfig['Version']) <= 50, 'Version fits TextMax50Type (AEAT XSD)', $passed, $failed, $total);
+assert_test(strlen($systemConfig['NumeroInstalacion']) <= 100, 'NumeroInstalacion fits TextMax100Type (AEAT XSD)', $passed, $failed, $total);
+
+// ---------------------------------------------------------------------------
+// Issue #33 - FNMT .p12 containers with legacy ciphers under OpenSSL 3
+// ---------------------------------------------------------------------------
+echo "Issue #33: legacy PKCS#12 containers under OpenSSL 3\n";
+
+require_once $moduleRoot . '/lib/functions/functions.certificates.php';
+
+// Error classification: the two failures must never be confused again.
+$legacyError = '4087B060787F0000:error:0308010C:digital envelope routines:'
+    . 'inner_evp_generic_fetch:unsupported:../crypto/evp/evp_fetch.c:386:'
+    . 'Global default library context, Algorithm (RC2-CBC : 4), Properties ()';
+$passwordError = 'Mac verify error: invalid password?';
+
+assert_test(isLegacyCipherOpensslError($legacyError), 'legacy cipher failure is recognised', $passed, $failed, $total);
+assert_test(!isWrongPasswordOpensslError($legacyError), 'legacy cipher failure is not reported as a wrong password', $passed, $failed, $total);
+assert_test(isWrongPasswordOpensslError($passwordError), 'wrong password failure is recognised', $passed, $failed, $total);
+assert_test(!isLegacyCipherOpensslError($passwordError), 'wrong password failure is not reported as a legacy cipher', $passed, $failed, $total);
+assert_test(!isLegacyCipherOpensslError(''), 'empty output is not classified as a legacy cipher', $passed, $failed, $total);
+assert_test(!isWrongPasswordOpensslError(''), 'empty output is not classified as a wrong password', $passed, $failed, $total);
+
+// The user-facing explanation must name the real cause.
+$legacyMessage = describeCertificateExtractionFailure(array(
+    'output' => $legacyError,
+    'legacy_cipher' => true,
+    'wrong_password' => false,
+));
+assert_test(stripos($legacyMessage, 'legacy') !== false, 'legacy failure message mentions the legacy algorithm', $passed, $failed, $total);
+assert_test(stripos($legacyMessage, 'password') === false || stripos($legacyMessage, 'not correct') === false, 'legacy failure message does not blame the password', $passed, $failed, $total);
+
+$passwordMessage = describeCertificateExtractionFailure(array(
+    'output' => $passwordError,
+    'legacy_cipher' => false,
+    'wrong_password' => true,
+));
+assert_test(stripos($passwordMessage, 'password') !== false, 'wrong password message mentions the password', $passed, $failed, $total);
+
+// End-to-end against real containers, when the OpenSSL binary is usable.
+$opensslUsable = function_exists('proc_open');
+$fixtureDir = sys_get_temp_dir() . '/verifactu_p12_' . getmypid();
+
+if ($opensslUsable) {
+    @mkdir($fixtureDir, 0700, true);
+    $quiet = ' 2>/dev/null';
+    $subject = '/C=ES/O=FNMT-RCM/CN=TEST USER - 12345678Z';
+    shell_exec('openssl req -x509 -newkey rsa:2048 -keyout ' . escapeshellarg($fixtureDir . '/key.pem')
+        . ' -out ' . escapeshellarg($fixtureDir . '/cert.pem')
+        . ' -days 2 -nodes -subj ' . escapeshellarg($subject) . $quiet);
+
+    $haveSource = file_exists($fixtureDir . '/key.pem') && file_exists($fixtureDir . '/cert.pem');
+
+    if ($haveSource) {
+        // A container encrypted the way older FNMT exports are.
+        shell_exec('openssl pkcs12 -export -legacy -certpbe RC2-40-CBC -keypbe PBE-SHA1-3DES'
+            . ' -in ' . escapeshellarg($fixtureDir . '/cert.pem')
+            . ' -inkey ' . escapeshellarg($fixtureDir . '/key.pem')
+            . ' -out ' . escapeshellarg($fixtureDir . '/legacy.p12')
+            . ' -password pass:secreto123' . $quiet);
+
+        // A container encrypted with current defaults, as a control.
+        shell_exec('openssl pkcs12 -export'
+            . ' -in ' . escapeshellarg($fixtureDir . '/cert.pem')
+            . ' -inkey ' . escapeshellarg($fixtureDir . '/key.pem')
+            . ' -out ' . escapeshellarg($fixtureDir . '/modern.p12')
+            . ' -password pass:secreto123' . $quiet);
+    }
+
+    if ($haveSource && file_exists($fixtureDir . '/legacy.p12') && file_exists($fixtureDir . '/modern.p12')) {
+        $legacyCert = extractPublicCertificateWithOpenSSL($fixtureDir . '/legacy.p12', 'secreto123');
+        assert_test(
+            !empty($legacyCert['success']),
+            'legacy .p12 with the right password yields the public certificate'
+                . (empty($legacyCert['success']) ? ' (' . $legacyCert['message'] . ')' : ''),
+            $passed,
+            $failed,
+            $total
+        );
+
+        $legacyKey = extractPrivateKeyWithOpenSSL($fixtureDir . '/legacy.p12', 'secreto123');
+        assert_test(!empty($legacyKey['success']), 'legacy .p12 with the right password yields the private key', $passed, $failed, $total);
+
+        $modernCert = extractPublicCertificateWithOpenSSL($fixtureDir . '/modern.p12', 'secreto123');
+        assert_test(!empty($modernCert['success']), 'modern .p12 still works (no regression)', $passed, $failed, $total);
+
+        $badPassword = extractPublicCertificateWithOpenSSL($fixtureDir . '/modern.p12', 'incorrecta');
+        assert_test(empty($badPassword['success']), 'a wrong password still fails', $passed, $failed, $total);
+        assert_test(!empty($badPassword['wrong_password']), 'a wrong password is reported as such', $passed, $failed, $total);
+
+        // The password reaches OpenSSL through the environment, so shell
+        // metacharacters must be inert rather than executed.
+        $canary = $fixtureDir . '/canary';
+        $injection = extractPublicCertificateWithOpenSSL($fixtureDir . '/modern.p12', 'a"; touch ' . $canary . '; #');
+        assert_test(empty($injection['success']), 'a password full of shell metacharacters simply fails', $passed, $failed, $total);
+        assert_test(!file_exists($canary), 'the password cannot inject shell commands', $passed, $failed, $total);
+    } else {
+        echo "  SKIP: could not build .p12 fixtures with the local openssl binary\n";
+    }
+
+    // Clean up fixtures.
+    foreach (glob($fixtureDir . '/*') as $leftover) {
+        @unlink($leftover);
+    }
+    @rmdir($fixtureDir);
+} else {
+    echo "  SKIP: proc_open is disabled, external OpenSSL not exercised\n";
+}
+
+echo "\n";
+
+// ---------------------------------------------------------------------------
+// Issue #30 (point 3) - proforma invoices must stay out of VeriFactu
+// ---------------------------------------------------------------------------
+echo "Issue #30 (3): proforma invoices excluded from VeriFactu\n";
+
+require_once $moduleRoot . '/lib/functions/functions.compatibility.php';
+
+/**
+ * Stand-in for a Dolibarr invoice with just the type discriminator.
+ */
+class VerifactuTestTypedInvoice
+{
+    /** @var int Dolibarr invoice type */
+    public $type;
+
+    /**
+     * @param int $type Dolibarr invoice type
+     */
+    public function __construct($type)
+    {
+        $this->type = $type;
+    }
+}
+
+// Dolibarr Facture type constants: 0 standard, 1 replacement, 2 proforma,
+// 3 credit note, 5 situation.
+assert_test(!isVerifactuApplicableInvoice(new VerifactuTestTypedInvoice(2)), 'proforma is excluded', $passed, $failed, $total);
+assert_test(isVerifactuApplicableInvoice(new VerifactuTestTypedInvoice(0)), 'standard invoice is included', $passed, $failed, $total);
+assert_test(isVerifactuApplicableInvoice(new VerifactuTestTypedInvoice(1)), 'replacement invoice is included', $passed, $failed, $total);
+assert_test(isVerifactuApplicableInvoice(new VerifactuTestTypedInvoice(3)), 'credit note is included', $passed, $failed, $total);
+assert_test(isVerifactuApplicableInvoice(new VerifactuTestTypedInvoice(5)), 'situation invoice is included', $passed, $failed, $total);
+assert_test(!isVerifactuApplicableInvoice(null), 'a non-object is excluded', $passed, $failed, $total);
+
+$triggerSource = file_get_contents($moduleRoot . '/core/triggers/interface_999_modVerifactu_VerifactuTriggers.class.php');
+assert_test(
+    strpos($triggerSource, 'isVerifactuApplicableInvoice($object)') !== false,
+    'billValidate() guards proformas before any VeriFactu processing',
+    $passed,
+    $failed,
+    $total
+);
+
+$submissionSource = file_get_contents($moduleRoot . '/lib/functions/functions.submission.php');
+assert_test(
+    strpos($submissionSource, 'isVerifactuApplicableInvoice($facture)') !== false,
+    'execVERIFACTUCall() guards proformas for every entry point',
+    $passed,
+    $failed,
+    $total
+);
+
+echo "\n";
+
+// ---------------------------------------------------------------------------
+// Issue #30 (point 5) - stored rectification type must match what is sent
+// ---------------------------------------------------------------------------
+echo "Issue #30 (5): stored rectification type matches the transmitted one\n";
+
+require_once $moduleRoot . '/lib/newfenix/src/Invoice.php';
+
+// billCreate() stores the type shown in the VeriFactu tab; functions.submission.php
+// decides what is actually transmitted. They must agree for non-TakePOS invoices.
+$storedCreditNoteType = null;
+if (preg_match('/case \$object::TYPE_CREDIT_NOTE:.*?VerifactuInvoice::(TYPE_\w+)/s', $triggerSource, $matches)) {
+    $storedCreditNoteType = $matches[1];
+}
+$storedReplacementType = null;
+if (preg_match('/case \$object::TYPE_REPLACEMENT:.*?VerifactuInvoice::(TYPE_\w+)/s', $triggerSource, $matches)) {
+    $storedReplacementType = $matches[1];
+}
+
+assert_test($storedCreditNoteType === 'TYPE_CREDIT_NOTE_LEGAL', 'credit note is stored as R1, the type actually sent', $passed, $failed, $total);
+assert_test($storedReplacementType === 'TYPE_CREDIT_NOTE_LEGAL', 'replacement invoice is stored as R1, the type actually sent', $passed, $failed, $total);
+assert_test(
+    OpenAEAT\Billing\Invoice::TYPE_CREDIT_NOTE_LEGAL === 'R1',
+    'TYPE_CREDIT_NOTE_LEGAL is the R1 code',
+    $passed,
+    $failed,
+    $total
+);
+
+$storedProformaType = null;
+if (preg_match('/case \$object::TYPE_PROFORMA:.*?options_verifactu_factura_tipo\'\] = ([^;]+);/s', $triggerSource, $matches)) {
+    $storedProformaType = trim($matches[1]);
+}
+assert_test($storedProformaType === "''", 'proforma gets no VeriFactu invoice type', $passed, $failed, $total);
+
+echo "\n=== Results ===\n";
+echo "Total:  $total\n";
+echo "Passed: $passed\n";
+echo "Failed: $failed\n";
+
+exit($failed > 0 ? 1 : 0);

--- a/tests/IssueFixesTest.php
+++ b/tests/IssueFixesTest.php
@@ -430,10 +430,23 @@ echo "Issue #30 (3): proforma invoices excluded from VeriFactu\n";
 require_once $moduleRoot . '/lib/functions/functions.compatibility.php';
 
 /**
- * Stand-in for a Dolibarr invoice with just the type discriminator.
+ * Stand-in for a Dolibarr invoice carrying the real type constants.
+ *
+ * The values are the ones Dolibarr actually uses (verified against 22.0.5,
+ * htdocs/compta/facture/class/facture.class.php and
+ * htdocs/core/class/commoninvoice.class.php). Getting these wrong is not
+ * academic: TYPE_CREDIT_NOTE is 2 and TYPE_PROFORMA is 4, so mistaking one for
+ * the other would silently drop every credit note from VeriFactu.
  */
 class VerifactuTestTypedInvoice
 {
+    const TYPE_STANDARD = 0;
+    const TYPE_REPLACEMENT = 1;
+    const TYPE_CREDIT_NOTE = 2;
+    const TYPE_DEPOSIT = 3;
+    const TYPE_PROFORMA = 4;
+    const TYPE_SITUATION = 5;
+
     /** @var int Dolibarr invoice type */
     public $type;
 
@@ -446,14 +459,46 @@ class VerifactuTestTypedInvoice
     }
 }
 
-// Dolibarr Facture type constants: 0 standard, 1 replacement, 2 proforma,
-// 3 credit note, 5 situation.
-assert_test(!isVerifactuApplicableInvoice(new VerifactuTestTypedInvoice(2)), 'proforma is excluded', $passed, $failed, $total);
-assert_test(isVerifactuApplicableInvoice(new VerifactuTestTypedInvoice(0)), 'standard invoice is included', $passed, $failed, $total);
-assert_test(isVerifactuApplicableInvoice(new VerifactuTestTypedInvoice(1)), 'replacement invoice is included', $passed, $failed, $total);
-assert_test(isVerifactuApplicableInvoice(new VerifactuTestTypedInvoice(3)), 'credit note is included', $passed, $failed, $total);
-assert_test(isVerifactuApplicableInvoice(new VerifactuTestTypedInvoice(5)), 'situation invoice is included', $passed, $failed, $total);
+assert_test(!isVerifactuApplicableInvoice(new VerifactuTestTypedInvoice(4)), 'proforma (type 4) is excluded', $passed, $failed, $total);
+assert_test(isVerifactuApplicableInvoice(new VerifactuTestTypedInvoice(0)), 'standard invoice (type 0) is included', $passed, $failed, $total);
+assert_test(isVerifactuApplicableInvoice(new VerifactuTestTypedInvoice(1)), 'replacement invoice (type 1) is included', $passed, $failed, $total);
+assert_test(isVerifactuApplicableInvoice(new VerifactuTestTypedInvoice(2)), 'credit note (type 2) is included - NOT mistaken for a proforma', $passed, $failed, $total);
+assert_test(isVerifactuApplicableInvoice(new VerifactuTestTypedInvoice(3)), 'deposit invoice (type 3) is included', $passed, $failed, $total);
+assert_test(isVerifactuApplicableInvoice(new VerifactuTestTypedInvoice(5)), 'situation invoice (type 5) is included', $passed, $failed, $total);
 assert_test(!isVerifactuApplicableInvoice(null), 'a non-object is excluded', $passed, $failed, $total);
+
+// An object with no type at all must not be dropped silently.
+assert_test(isVerifactuApplicableInvoice(new stdClass()), 'an object without a type is kept in scope', $passed, $failed, $total);
+
+// The constants must match the ones a real Dolibarr install exposes. If Dolibarr
+// is available locally, assert against its own source rather than our copy.
+$dolibarrFacture = getenv('DOLIBARR_HTDOCS') . '/compta/facture/class/facture.class.php';
+if (getenv('DOLIBARR_HTDOCS') && is_readable($dolibarrFacture)) {
+    $factureSource = file_get_contents($dolibarrFacture);
+    preg_match('/const TYPE_PROFORMA\s*=\s*(\d+)/', $factureSource, $m);
+    $realProforma = isset($m[1]) ? (int) $m[1] : null;
+    preg_match('/const TYPE_CREDIT_NOTE\s*=\s*(\d+)/', $factureSource, $m);
+    $realCreditNote = isset($m[1]) ? (int) $m[1] : null;
+
+    assert_test($realProforma === 4, 'real Dolibarr TYPE_PROFORMA is 4', $passed, $failed, $total);
+    assert_test($realCreditNote === 2, 'real Dolibarr TYPE_CREDIT_NOTE is 2', $passed, $failed, $total);
+    assert_test(
+        !isVerifactuApplicableInvoice(new VerifactuTestTypedInvoice($realProforma)),
+        'real Dolibarr proforma type is excluded',
+        $passed,
+        $failed,
+        $total
+    );
+    assert_test(
+        isVerifactuApplicableInvoice(new VerifactuTestTypedInvoice($realCreditNote)),
+        'real Dolibarr credit note type is included',
+        $passed,
+        $failed,
+        $total
+    );
+} else {
+    echo "  SKIP: set DOLIBARR_HTDOCS to cross-check the type constants against a real install\n";
+}
 
 $triggerSource = file_get_contents($moduleRoot . '/core/triggers/interface_999_modVerifactu_VerifactuTriggers.class.php');
 assert_test(

--- a/tests/IssueFixesTest.php
+++ b/tests/IssueFixesTest.php
@@ -350,6 +350,31 @@ $passwordMessage = describeCertificateExtractionFailure(array(
 ));
 assert_test(stripos($passwordMessage, 'password') !== false, 'wrong password message mentions the password', $passed, $failed, $total);
 
+// The -legacy switch only exists in OpenSSL 3+. Adding it on an older binary
+// would turn a working extraction into an "unknown option" failure, so the
+// version gate matters on servers still running OpenSSL 1.1.1 (Ubuntu 20.04)
+// or LibreSSL. The detection is a regex over `openssl version`, exercised here
+// directly because those binaries cannot be installed alongside this one.
+$legacyFlagRegex = '/OpenSSL\s+([3-9]|\d{2,})\./';
+$versionExpectations = array(
+    'OpenSSL 3.0.13 30 Jan 2024' => true,
+    'OpenSSL 3.5.0 8 Apr 2025' => true,
+    'OpenSSL 1.1.1f  31 Mar 2020' => false,
+    'OpenSSL 1.0.2k-fips  26 Jan 2017' => false,
+    'LibreSSL 2.8.3' => false,
+    'OpenSSL 10.0.0 1 Jan 2030' => true,
+);
+foreach ($versionExpectations as $versionString => $shouldSupport) {
+    $detected = (preg_match($legacyFlagRegex, $versionString) === 1);
+    assert_test(
+        $detected === $shouldSupport,
+        "'" . $versionString . "' " . ($shouldSupport ? 'supports' : 'does not support') . ' -legacy',
+        $passed,
+        $failed,
+        $total
+    );
+}
+
 // End-to-end against real containers, when the OpenSSL binary is usable.
 $opensslUsable = function_exists('proc_open');
 $fixtureDir = sys_get_temp_dir() . '/verifactu_p12_' . getmypid();

--- a/tests/IssueFixesTest.php
+++ b/tests/IssueFixesTest.php
@@ -445,11 +445,47 @@ if ($opensslUsable) {
     echo "  SKIP: proc_open is disabled, external OpenSSL not exercised\n";
 }
 
+// Shared hosting (PR #42 feedback): exec() and proc_open() are both in
+// disable_functions on Loading.es, Hostinger and similar. The extraction must
+// still work there through PHP's own OpenSSL bindings, otherwise the module
+// cannot talk to AEAT at all on those servers.
+assert_test(function_exists('extractPkcs12WithPhp'), 'a PHP-native PKCS#12 path exists', $passed, $failed, $total);
+assert_test(function_exists('isPhpFunctionAvailable'), 'disable_functions is taken into account', $passed, $failed, $total);
+assert_test(isPhpFunctionAvailable('strlen'), 'an enabled function is reported available', $passed, $failed, $total);
+assert_test(!isPhpFunctionAvailable('a_function_that_does_not_exist'), 'a missing function is reported unavailable', $passed, $failed, $total);
+
+$certificatesSource = file_get_contents($moduleRoot . '/lib/functions/functions.certificates.php');
+assert_test(
+    strpos($certificatesSource, "isPhpFunctionAvailable('proc_open')") !== false,
+    'the external binary is only used when proc_open is really callable',
+    $passed,
+    $failed,
+    $total
+);
+// Look for real calls, not the word appearing in a comment: tokenise and keep
+// only T_STRING tokens naming a process function.
+$processFunctions = array('exec', 'shell_exec', 'passthru', 'system', 'popen');
+$calledProcessFunctions = array();
+foreach (token_get_all($certificatesSource) as $token) {
+    if (is_array($token) && $token[0] === T_STRING && in_array(strtolower($token[1]), $processFunctions, true)) {
+        $calledProcessFunctions[] = $token[1];
+    }
+}
+assert_test(
+    empty($calledProcessFunctions),
+    'no shell-spawning call is left in the certificate code'
+        . ($calledProcessFunctions ? ' (found: ' . implode(', ', array_unique($calledProcessFunctions)) . ')' : ''),
+    $passed,
+    $failed,
+    $total
+);
+
 echo "\n";
 
 // ---------------------------------------------------------------------------
 // Issue #30 (point 3) - proforma invoices must stay out of VeriFactu
 // ---------------------------------------------------------------------------
+
 echo "Issue #30 (3): proforma invoices excluded from VeriFactu\n";
 
 require_once $moduleRoot . '/lib/functions/functions.compatibility.php';


### PR DESCRIPTION
Corrige los errores reportados en las cuatro issues abiertas. Cada fallo se ha reproducido antes de tocar código y se ha verificado después sobre instalaciones reales de Dolibarr 17.0.2 y 22.0.5.

Closes #31
Closes #32
Closes #33
Aborda parcialmente #30 (puntos 1, 2, 3, 5 y 6; el punto 4 y la parametrización por tenant quedan pendientes de diseño)

---

## Correcciones

### #31 — Fatal error en el informe de pagos

`beforePDFCreation()` llamaba a `fetch_optionals()` sin comprobar el tipo del objeto. Ese hook no lo disparan solo los modelos PDF de factura: los de informe (`pdf_paiement`, `pdf_paiement_fourn`) también lo lanzan, y lo que pasan **no es una factura**:

| Versión | Qué pasa al hook | Resultado sin guard |
|---|---|---|
| 22.0.5 | el propio modelo PDF (`$this`), que extiende `CommonDocGenerator` | `Call to undefined method pdf_paiement_fourn::fetch_optionals()` |
| 17.0.2 | una variable `$object` que **nunca se asigna** en `write_file()`, es decir `null` | `Call to a member function fetch_optionals() on null` |

El fallo no era exclusivo de la 22: estaba latente en la 17 igualmente y solo cambiaba el mensaje. El guard comprueba `is_object()` antes que `method_exists()`, así que cubre los dos casos. De paso se deja de acceder al extrafield cuando no está definido, lo que eliminaba además un warning de PHP 8.

### #32 — TypeError en el QR con PHP 8

`QRGenerator::renderQrCode()` declaraba `int $outputType`, pero las constantes de `chillerlan/php-qrcode` son strings (`QROutputInterface::GDIMAGE_PNG = 'png'`, `MARKUP_SVG = 'svg'`). Con `declare(strict_types=1)` toda llamada fallaba, rompiendo la pestaña VeriFactu y la vista de factura.

Corregido el tipo del parámetro a `string`, manteniendo el type hint explícito en lugar de eliminarlo. El QR del PDF nunca estuvo afectado: usa `TCPDF::write2DBarcode()`, que es una ruta independiente.

### #33 — Certificados FNMT `.p12` con cifrado legacy

Los contenedores PKCS#12 protegidos con `RC2-40-CBC` / `PBE-SHA1-3DES` fallan bajo OpenSSL 3, que desactiva esos algoritmos por defecto, y el módulo lo notificaba como *"Verifique la contraseña"*.

- La extracción reintenta automáticamente con `openssl pkcs12 -legacy`.
- El reintento está condicionado a que el binario sea **OpenSSL 3 o superior**: en OpenSSL 1.1.1 o LibreSSL ese modificador no existe y añadirlo convertiría una extracción correcta en un error de "opción desconocida".
- El mensaje de error distingue entre contraseña incorrecta, algoritmo legacy no soportado y fallo genérico, en los cinco idiomas.
- Documentado en el README con las dos soluciones alternativas para el servidor.

### #30 punto 1 y 6 — Identidad del sistema declarada vs. transmitida

La declaración responsable declaraba `VERIFACTU-DOLIBARR-OSS` / `VeriFactu para Dolibarr ERP/CRM` mientras que a la AEAT se enviaban `DV` / `Dolibarr Verifactu Module`. El Art. 15.2 de la Orden HAC/1177/2024 exige que coincidan.

**La unificación va en dirección contraria a la propuesta en la issue**, porque el esquema oficial manda. Estos son los tipos declarados en `SuministroInformacion.xsd`, bloque `SistemaInformatico` (líneas 235-238):

| Campo | Tipo en el XSD | Límite |
|---|---|---|
| `NombreSistemaInformatico` | `sf:TextMax30Type` | **30 caracteres** |
| `IdSistemaInformatico` | `sf:TextMax2Type` | **2 caracteres** |
| `Version` | `sf:TextMax50Type` | 50 caracteres |
| `NumeroInstalacion` | `sf:TextMax100Type` | 100 caracteres |

`IdSistemaInformatico` admite **2 caracteres**, no los 22 de `VERIFACTU-DOLIBARR-OSS`. Y `VeriFactu para Dolibarr ERP/CRM` son 31 caracteres, uno por encima del límite de 30. Es decir: los valores correctos eran los que ya se transmitían, y lo que estaba mal era la declaración.

El comentario del propio fichero decía `@format Alfanumérico, máximo 30 caracteres` para `id_sistema_informatico`, que es falso y probablemente el origen del malentendido; también corregido a 2.

`getSystemConfig()` lee ahora la identidad de la propia declaración responsable mediante `getDeclaredSystemIdentity()` y aplica los límites del XSD, de modo que no pueden volver a divergir.

**Además**, el campo `Version` transmitía `DOL_VERSION`, es decir la versión de Dolibarr y no la del módulo, que es lo que exige el Art. 15.2.c). Corregido.

### #30 punto 2 — Hash de integridad incompleto

La lista `ficheros_verificados` referenciaba `interface_99_...` en vez de `interface_999_...`, y además `class/verifactu.class.php`, que no existe en el repositorio: eran **dos de seis** ficheros fuera del cálculo, no uno.

Corregida y ampliada con los ficheros críticos de hash, envío, anulación y configuración. Y sobre la raíz del problema: `calcularHashModuloVerifactu()` ignoraba en silencio los ficheros ausentes; ahora los registra en `integridad.ficheros_no_encontrados` y en el log.

### #30 punto 3 — Facturas proforma enviadas como F1

Una proforma no es una factura expedida legalmente y no debe generar registro de facturación (Art. 6 RD 1007/2023). Nueva función `isVerifactuApplicableInvoice()` aplicada en dos puntos:

- `billValidate()`, antes de cualquier procesamiento VeriFactu.
- `execVERIFACTUCall()`, que es el punto único por el que pasan todas las vías de envío.

El guard en el trigger es imprescindible y no basta con el de `execVERIFACTUCall()`: esa función devuelve `false` en caso de fallo y el trigger interpreta ese `false` revirtiendo la factura a borrador, con lo que las proformas dejarían de poder validarse en Dolibarr.

### #30 punto 5 — Tipo rectificativo divergente

`billCreate()` almacenaba R2 para abonos y facturas de sustitución mientras el envío transmitía R1, por lo que la pestaña VeriFactu mostraba un tipo que nunca era el enviado. Unificado a R1, que es lo que realmente se transmite: no cambia nada de lo que se envía a la AEAT, solo hace que la interfaz diga la verdad.

---

## Seguridad

- La contraseña del certificado ya no se interpola en la línea de comandos de `openssl`. Las llamadas usan `proc_open` con argumentos en array y pasan la contraseña por variable de entorno (`-password env:`), lo que elimina la posibilidad de inyección de comandos a través de la contraseña y evita que quede visible en la lista de procesos del servidor. Hay un test que lo comprueba con una contraseña llena de metacaracteres de shell.
- `prepareLocalCertificate()` ya no hace `die()` ante un fallo de extracción, que tumbaba la petición entera: lanza una excepción que el llamador convierte en el mensaje de error habitual del módulo.

---

## Un error propio, encontrado al verificar

`isVerifactuApplicableInvoice()` usaba el literal `2` como valor de respaldo para `Facture::TYPE_PROFORMA`. Pero en Dolibarr `TYPE_PROFORMA` es **4** y el **2 es `TYPE_CREDIT_NOTE`**: si la clase `Facture` no estuviera cargada, la función habría excluido de VeriFactu **todos los abonos**.

Los tests en aislamiento no lo cazaban porque codificaban la misma suposición equivocada. Apareció al comprobar las constantes contra las clases reales de Dolibarr. Ahora la constante se resuelve desde la clase del propio objeto, con `Facture` y `CommonInvoice` como alternativas y el literal como último recurso; un objeto sin tipo se considera dentro del ámbito para no descartar en silencio una factura real. Los tests se corrigieron y se les añadió una comprobación cruzada opcional contra una instalación real vía `DOLIBARR_HTDOCS`.

Verificado que la numeración es idéntica en 17.0.2 y 22.0.5: `0` estándar, `1` sustitución, `2` abono, `3` anticipo, `4` proforma, `5` situación.

---

## Verificación

Instalaciones completas sobre PostgreSQL 16, con el instalador de Dolibarr y el módulo activado mediante `activateModule()`. No son simulaciones: el hook se dispara con el objeto que realmente pasa cada versión, los QR se generan a través de `getQrImage()` / `getQrBase64()` y las constantes se leen de la clase `Facture` real.

| Entorno | Resultado |
|---|---|
| Dolibarr 22.0.5 + PHP 8.4 | 22/22 |
| Dolibarr 17.0.2 + PHP 8.2 | 20/20 |
| Dolibarr 17.0.2 + PHP 8.4 | 20/20 |
| Dolibarr 17.0.2 + PHP 7.4 (mínimo declarado del módulo) | 20/20 |
| `tests/IssueFixesTest.php` en PHP 7.4 / 8.2 / 8.4 | 59/59 |
| `tests/SchemaManagerTest.php` (existente) | 19/19 |
| `tests/MassValidateInterceptionTest.php` (existente) | 52/52 |

La suite de regresión genera durante su ejecución contenedores `.p12` legacy y modernos reales, de modo que el caso concreto de la issue #33 se comprueba de verdad en cada ejecución.

---

## Pendiente antes de mergear

- **Envío de prueba contra el entorno de pruebas de la AEAT.** No se ha podido hacer aquí: requiere certificado válido y acceso al webservice. Los cambios no tocan la construcción del SOAP, pero **sí modifican lo que va en el bloque `SistemaInformatico`** (`IdSistemaInformatico`, `NombreSistemaInformatico` y `Version`), así que conviene un alta de prueba antes de publicar.
- **Pantallas de administración de certificados.** La verificación es programática sobre funciones y hooks; no se ha ejercitado un POST real de subida de certificado desde el navegador.
- **Revisión del punto 1 de la #30.** Es el cambio con más consecuencias. Merece una segunda lectura del XSD por parte de alguien más antes de integrarlo.

## Fuera de alcance

El punto 4 de la #30 (cola serializada `llx_verifactu_queue` para el envío obligatorio en validación y la condición de carrera del encadenamiento) y la parametrización de la declaración responsable por tenant **no se abordan aquí**. El diagnóstico de ambos es correcto, pero son cambios arquitectónicos con tabla nueva, migración y proceso consumidor, y están en discusión en la propia issue.

---

## Versión

Se unifica en **1.0.5**. La clase del módulo se había quedado en 1.0.3, el README iba por 1.0.4 y la declaración responsable por 1.0.2. Ahora las tres coinciden, lo que importa porque ese valor es el que se transmite a la AEAT.